### PR TITLE
Bump timeout for all builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
       }
   - SET PATH=C:\sbt\sbt\bin;%PATH%
-  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8 -Dswoval.skip.native=true
+  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8 -Dswoval.skip.native=true -Dswoval.fork.tests=true
 test_script:
   - sbt "filesJVM/test" "filesJS/test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
        CMD="filesJVM/test plugin/compile"
        TRAVIS_SCALA_VERSION=2.10.7
 
-script: ./sbt/bin/sbt -Dsbt.version=$SBT_VER -Dswoval.skip.native=true ++$TRAVIS_SCALA_VERSION $CMD
+script: ./sbt/bin/sbt -Dsbt.version=$SBT_VER -Dswoval.skip.native=true -Dswoval.fork.tests=true ++$TRAVIS_SCALA_VERSION $CMD
 
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8408

--- a/files/js/src/main/scala/com/swoval/files/FileCache.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileCache.scala
@@ -282,14 +282,15 @@ private[files] class FileCacheImpl[T](private val converter: Converter[T],
   private val callback: DirectoryWatcher.Callback =
     new DirectoryWatcher.Callback() {
       override def apply(event: DirectoryWatcher.Event): Unit = {
-        lock.synchronized {
+        lock.lock()
+        try {
           val path: Path = event.path
           if (event.kind == Overflow) {
             handleOverflow(path)
           } else {
             handleEvent(path)
           }
-        }
+        } finally lock.unlock()
       }
     }
 

--- a/files/js/src/main/scala/com/swoval/files/apple/FileEventsApi.scala
+++ b/files/js/src/main/scala/com/swoval/files/apple/FileEventsApi.scala
@@ -1,5 +1,7 @@
 package com.swoval.files.apple
 
+import java.io.IOException
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -44,6 +46,7 @@ class FileEventsApi(handle: Double) extends AutoCloseable {
 
 @JSExportTopLevel("com.swoval.files.apple.FileEventsApi$")
 object FileEventsApi {
+  class ClosedFileEventsApiException(msg: String) extends IOException(msg)
   trait Consumer[T] {
     def accept(t: T): Unit
   }

--- a/files/jvm/src/main/java/com/swoval/files/FileCache.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCache.java
@@ -270,14 +270,15 @@ class FileCacheImpl<T> extends FileCache<T> {
         @SuppressWarnings("unchecked")
         @Override
         public void apply(final DirectoryWatcher.Event event) {
-          synchronized (lock) {
+          lock.lock();
+          try {
             final Path path = event.path;
             if (event.kind.equals(Overflow)) {
               handleOverflow(path);
             } else {
               handleEvent(path);
             }
-          }
+          } finally { lock.unlock(); }
         }
       };
   private final DirectoryWatcher watcher;

--- a/files/jvm/src/main/java/com/swoval/files/FileCache.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCache.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -262,6 +263,7 @@ class FileCacheImpl<T> extends FileCache<T> {
   private final Converter<T> converter;
   private final ReentrantLock lock = new ReentrantLock();
   private final SymlinkWatcher symlinkWatcher;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   private final DirectoryWatcher.Callback callback =
       new DirectoryWatcher.Callback() {
@@ -271,14 +273,7 @@ class FileCacheImpl<T> extends FileCache<T> {
           synchronized (lock) {
             final Path path = event.path;
             if (event.kind.equals(Overflow)) {
-              try {
-                handleOverflow(path);
-              } catch (IOException e) {
-                System.err.println("FileCache caught IOException while processing overflow: " + e);
-                for (StackTraceElement el : e.getStackTrace()) {
-                  System.out.println(el);
-                }
-              }
+              handleOverflow(path);
             } else {
               handleEvent(path);
             }
@@ -314,13 +309,15 @@ class FileCacheImpl<T> extends FileCache<T> {
   /** Cleans up the directory watcher and clears the directory cache. */
   @Override
   public void close() {
-    watcher.close();
-    if (symlinkWatcher != null) symlinkWatcher.close();
-    final Iterator<Directory<T>> directoryIterator = directories.values().iterator();
-    while (directoryIterator.hasNext()) {
-      directoryIterator.next().close();
+    if (closed.compareAndSet(false, true)) {
+      if (symlinkWatcher != null) symlinkWatcher.close();
+      watcher.close();
+      final Iterator<Directory<T>> directoryIterator = directories.values().iterator();
+      while (directoryIterator.hasNext()) {
+        directoryIterator.next().close();
+      }
+      directories.clear();
     }
-    directories.clear();
   }
 
   @Override
@@ -442,136 +439,142 @@ class FileCacheImpl<T> extends FileCache<T> {
   }
 
   @SuppressWarnings("unchecked")
-  private boolean handleOverflow(final Path path) throws IOException {
+  private boolean handleOverflow(final Path path) {
     synchronized (directories) {
-      final Iterator<Directory<T>> directoryIterator = directories.values().iterator();
-      final List<Directory<T>> toReplace = new ArrayList<>();
-      final List<Directory.Entry<T>> creations = new ArrayList<>();
-      final List<Directory.Entry<T>[]> updates = new ArrayList<>();
-      final List<Directory.Entry<T>> deletions = new ArrayList<>();
-      while (directoryIterator.hasNext()) {
-        final Directory<T> currentDir = directoryIterator.next();
-        if (path.startsWith(currentDir.path)) {
-          Directory<T> oldDir = currentDir;
-          Directory<T> newDir = cachedOrNull(oldDir.path, oldDir.getDepth());
-          while (newDir == null || diff(oldDir, newDir)) {
-            if (newDir != null) oldDir = newDir;
-            newDir = cachedOrNull(oldDir.path, oldDir.getDepth());
-          }
-          final Map<Path, Directory.Entry<T>> oldEntries = new HashMap<>();
-          final Map<Path, Directory.Entry<T>> newEntries = new HashMap<>();
-          final Iterator<Directory.Entry<T>> oldEntryIterator =
-              currentDir.list(currentDir.recursive(), AllPass).iterator();
-          while (oldEntryIterator.hasNext()) {
-            final Directory.Entry<T> entry = oldEntryIterator.next();
-            oldEntries.put(entry.path, entry);
-          }
-          final Iterator<Directory.Entry<T>> newEntryIterator =
-              newDir.list(currentDir.recursive(), AllPass).iterator();
-          while (newEntryIterator.hasNext()) {
-            final Directory.Entry<T> entry = newEntryIterator.next();
-            newEntries.put(entry.path, entry);
-          }
-          final Iterator<Entry<Path, Directory.Entry<T>>> oldIterator =
-              oldEntries.entrySet().iterator();
-          while (oldIterator.hasNext()) {
-            final Entry<Path, Directory.Entry<T>> mapEntry = oldIterator.next();
-            if (!newEntries.containsKey(mapEntry.getKey())) {
-              deletions.add(mapEntry.getValue());
+      if (!closed.get()) {
+        final Iterator<Directory<T>> directoryIterator = directories.values().iterator();
+        final List<Directory<T>> toReplace = new ArrayList<>();
+        final List<Directory.Entry<T>> creations = new ArrayList<>();
+        final List<Directory.Entry<T>[]> updates = new ArrayList<>();
+        final List<Directory.Entry<T>> deletions = new ArrayList<>();
+        while (directoryIterator.hasNext()) {
+          final Directory<T> currentDir = directoryIterator.next();
+          if (path.startsWith(currentDir.path)) {
+            Directory<T> oldDir = currentDir;
+            Directory<T> newDir = cachedOrNull(oldDir.path, oldDir.getDepth());
+            while (newDir == null || diff(oldDir, newDir)) {
+              if (newDir != null) oldDir = newDir;
+              newDir = cachedOrNull(oldDir.path, oldDir.getDepth());
             }
-          }
-          final Iterator<Entry<Path, Directory.Entry<T>>> newIterator =
-              newEntries.entrySet().iterator();
-          while (newIterator.hasNext()) {
-            final Entry<Path, Directory.Entry<T>> mapEntry = newIterator.next();
-            if (!oldEntries.containsKey(mapEntry.getKey())) {
-              creations.add(mapEntry.getValue());
-            } else {
-              final Directory.Entry<T> oldEntry = oldEntries.get(mapEntry.getKey());
-              if (!oldEntry.equals(mapEntry.getValue())) {}
+            final Map<Path, Directory.Entry<T>> oldEntries = new HashMap<>();
+            final Map<Path, Directory.Entry<T>> newEntries = new HashMap<>();
+            final Iterator<Directory.Entry<T>> oldEntryIterator =
+                currentDir.list(currentDir.recursive(), AllPass).iterator();
+            while (oldEntryIterator.hasNext()) {
+              final Directory.Entry<T> entry = oldEntryIterator.next();
+              oldEntries.put(entry.path, entry);
             }
+            final Iterator<Directory.Entry<T>> newEntryIterator =
+                newDir.list(currentDir.recursive(), AllPass).iterator();
+            while (newEntryIterator.hasNext()) {
+              final Directory.Entry<T> entry = newEntryIterator.next();
+              newEntries.put(entry.path, entry);
+            }
+            final Iterator<Entry<Path, Directory.Entry<T>>> oldIterator =
+                oldEntries.entrySet().iterator();
+            while (oldIterator.hasNext()) {
+              final Entry<Path, Directory.Entry<T>> mapEntry = oldIterator.next();
+              if (!newEntries.containsKey(mapEntry.getKey())) {
+                deletions.add(mapEntry.getValue());
+              }
+            }
+            final Iterator<Entry<Path, Directory.Entry<T>>> newIterator =
+                newEntries.entrySet().iterator();
+            while (newIterator.hasNext()) {
+              final Entry<Path, Directory.Entry<T>> mapEntry = newIterator.next();
+              if (!oldEntries.containsKey(mapEntry.getKey())) {
+                creations.add(mapEntry.getValue());
+              } else {
+                final Directory.Entry<T> oldEntry = oldEntries.get(mapEntry.getKey());
+                if (!oldEntry.equals(mapEntry.getValue())) {}
+              }
+            }
+            toReplace.add(newDir);
           }
-          toReplace.add(newDir);
         }
+        final Iterator<Directory<T>> replacements = toReplace.iterator();
+        while (replacements.hasNext()) {
+          final Directory<T> replacement = replacements.next();
+          directories.put(replacement.path, replacement);
+        }
+        final Iterator<Directory.Entry<T>> creationIterator = creations.iterator();
+        while (creationIterator.hasNext()) observers.onCreate(creationIterator.next());
+        final Iterator<Directory.Entry<T>> deletionIterator = deletions.iterator();
+        while (deletionIterator.hasNext()) observers.onDelete(deletionIterator.next());
+        final Iterator<Directory.Entry<T>[]> updateIterator = updates.iterator();
+        while (updateIterator.hasNext()) {
+          final Directory.Entry<T>[] update = updateIterator.next();
+          observers.onUpdate(update[0], update[1]);
+        }
+        return creations.isEmpty() && deletions.isEmpty() && updates.isEmpty();
+      } else {
+        return false;
       }
-      final Iterator<Directory<T>> replacements = toReplace.iterator();
-      while (replacements.hasNext()) {
-        final Directory<T> replacement = replacements.next();
-        directories.put(replacement.path, replacement);
-      }
-      final Iterator<Directory.Entry<T>> creationIterator = creations.iterator();
-      while (creationIterator.hasNext()) observers.onCreate(creationIterator.next());
-      final Iterator<Directory.Entry<T>> deletionIterator = deletions.iterator();
-      while (deletionIterator.hasNext()) observers.onDelete(deletionIterator.next());
-      final Iterator<Directory.Entry<T>[]> updateIterator = updates.iterator();
-      while (updateIterator.hasNext()) {
-        final Directory.Entry<T>[] update = updateIterator.next();
-        observers.onUpdate(update[0], update[1]);
-      }
-      return creations.isEmpty() && deletions.isEmpty() && updates.isEmpty();
     }
   }
 
   @SuppressWarnings("EmptyCatchBlock")
   private void handleEvent(final Path path) {
-    BasicFileAttributes attrs = null;
-    try {
-      attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-    } catch (IOException e) {
-    }
-    if (attrs != null) {
-      final Pair<Directory<T>, List<Directory.Entry<T>>> pair =
-          listImpl(
-              path,
-              0,
-              new Directory.EntryFilter<T>() {
-                @Override
-                public boolean accept(Directory.Entry<? extends T> entry) {
-                  return path.equals(entry.path);
+    if (!closed.get()) {
+      BasicFileAttributes attrs = null;
+      try {
+        attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      } catch (IOException e) {
+      }
+      if (attrs != null) {
+        final Pair<Directory<T>, List<Directory.Entry<T>>> pair =
+            listImpl(
+                path,
+                0,
+                new Directory.EntryFilter<T>() {
+                  @Override
+                  public boolean accept(Directory.Entry<? extends T> entry) {
+                    return path.equals(entry.path);
+                  }
+                });
+        if (pair != null) {
+          final Directory<T> dir = pair.first;
+          final List<Directory.Entry<T>> paths = pair.second;
+          if (!paths.isEmpty() || !path.equals(dir.path)) {
+            final Path toUpdate = paths.isEmpty() ? path : paths.get(0).path;
+            if (attrs.isSymbolicLink() && symlinkWatcher != null)
+              symlinkWatcher.addSymlink(path, Files.isDirectory(path));
+            try {
+              final Iterator<Directory.Entry<T>[]> it =
+                  dir.addUpdate(toUpdate, Directory.Entry.getKind(toUpdate, attrs)).iterator();
+              while (it.hasNext()) {
+                final Directory.Entry<T>[] entry = it.next();
+                if (entry.length == 2) {
+                  observers.onUpdate(entry[0], entry[1]);
+                } else {
+                  observers.onCreate(entry[0]);
                 }
-              });
-      if (pair != null) {
-        final Directory<T> dir = pair.first;
-        final List<Directory.Entry<T>> paths = pair.second;
-        if (!paths.isEmpty() || !path.equals(dir.path)) {
-          final Path toUpdate = paths.isEmpty() ? path : paths.get(0).path;
-          if (attrs.isSymbolicLink() && symlinkWatcher != null)
-            symlinkWatcher.addSymlink(path, Files.isDirectory(path));
-          try {
-            final Iterator<Directory.Entry<T>[]> it =
-                dir.addUpdate(toUpdate, Directory.Entry.getKind(toUpdate, attrs)).iterator();
-            while (it.hasNext()) {
-              final Directory.Entry<T>[] entry = it.next();
-              if (entry.length == 2) {
-                observers.onUpdate(entry[0], entry[1]);
-              } else {
-                observers.onCreate(entry[0]);
               }
+            } catch (IOException e) {
+              observers.onError(path, e);
             }
-          } catch (IOException e) {
-            observers.onError(path, e);
           }
         }
-      }
-    } else {
-      final List<Iterator<Directory.Entry<T>>> removeIterators = new ArrayList<>();
-      synchronized (directories) {
-        final Iterator<Directory<T>> it = directories.values().iterator();
+      } else {
+        final List<Iterator<Directory.Entry<T>>> removeIterators = new ArrayList<>();
+        synchronized (directories) {
+          final Iterator<Directory<T>> it = directories.values().iterator();
+          while (it.hasNext()) {
+            final Directory<T> dir = it.next();
+            if (path.startsWith(dir.path)) {
+              removeIterators.add(dir.remove(path).iterator());
+            }
+          }
+        }
+        final Iterator<Iterator<Directory.Entry<T>>> it = removeIterators.iterator();
         while (it.hasNext()) {
-          final Directory<T> dir = it.next();
-          if (path.startsWith(dir.path)) {
-            removeIterators.add(dir.remove(path).iterator());
-          }
-        }
-      }
-      final Iterator<Iterator<Directory.Entry<T>>> it = removeIterators.iterator();
-      while (it.hasNext()) {
-        final Iterator<Directory.Entry<T>> removeIterator = it.next();
-        while (removeIterator.hasNext()) {
-          final Directory.Entry<T> entry = removeIterator.next();
-          observers.onDelete(entry);
-          if (symlinkWatcher != null) {
-            symlinkWatcher.remove(entry.path);
+          final Iterator<Directory.Entry<T>> removeIterator = it.next();
+          while (removeIterator.hasNext()) {
+            final Directory.Entry<T> entry = removeIterator.next();
+            observers.onDelete(entry);
+            if (symlinkWatcher != null) {
+              symlinkWatcher.remove(entry.path);
+            }
           }
         }
       }

--- a/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
@@ -66,7 +66,7 @@ public class NioDirectoryWatcher extends DirectoryWatcher {
         new Thread("NioDirectoryWatcher-loop-thread-" + threadId.incrementAndGet()) {
           @Override
           public void run() {
-            while (!isStopped.get()) {
+            while (!isStopped.get() && !Thread.currentThread().isInterrupted()) {
               try {
                 final WatchKey key = watchService.take();
                 final Iterator<WatchEvent<?>> it = key.pollEvents().iterator();

--- a/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
@@ -9,11 +9,8 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 
-import com.swoval.files.apple.FileEventsApi.ClosedFileEventsApiException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
-import java.nio.file.FileSystems;
 import java.nio.file.FileSystemLoopException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -21,7 +18,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
 import java.nio.file.Watchable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -113,13 +109,16 @@ public class NioDirectoryWatcher extends DirectoryWatcher {
         loopThread.join(5000);
       } catch (InterruptedException e) {
       }
-      synchronized (lock) {
+      lock.lock();
+      try {
         final Iterator<WatchedDir> it = watchedDirs.values().iterator();
         while (it.hasNext()) {
           WatchKey key = it.next().key;
           key.cancel();
           key.reset();
         }
+      } finally {
+        lock.unlock();
       }
     }
   }
@@ -177,7 +176,8 @@ public class NioDirectoryWatcher extends DirectoryWatcher {
       boolean stop = false;
       while ((watchedDir != null && watchedDir.maxDepth > 0) && !stop) {
         try {
-          final Iterator<QuickFile> fileIterator = QuickList.list((Path) key.watchable(), watchedDir.maxDepth).iterator();
+          final Iterator<QuickFile> fileIterator =
+              QuickList.list((Path) key.watchable(), watchedDir.maxDepth).iterator();
           boolean registered = false;
           while (fileIterator.hasNext()) {
             final QuickFile file = fileIterator.next();
@@ -222,9 +222,9 @@ public class NioDirectoryWatcher extends DirectoryWatcher {
 
   /**
    * Similar to register, but tracks all of the new files found in the directory. It polls the
-   * directory until the contents stop changing to ensure that a callback is fired for each path
-   * in the newly created directory (up to the maxDepth). The assumption is that once the callback
-   * is fired for the path, it is safe to assume that no event for a new file in the directory is
+   * directory until the contents stop changing to ensure that a callback is fired for each path in
+   * the newly created directory (up to the maxDepth). The assumption is that once the callback is
+   * fired for the path, it is safe to assume that no event for a new file in the directory is
    * missed. Without the polling, it would be possible that a new file was created in the directory
    * before we registered it with the watch service. If this happened, then no callback would be
    * invoked for that file.
@@ -336,7 +336,8 @@ public class NioDirectoryWatcher extends DirectoryWatcher {
     Path realPath = null;
     try {
       realPath = path.toRealPath();
-    } catch (IOException e) {}
+    } catch (IOException e) {
+    }
     final WatchedDir watchedDir = watchedDirs.remove(realPath == null ? path : realPath);
     if (watchedDir != null) {
       WatchKey key = watchedDir.key;

--- a/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioDirectoryWatcher.java
@@ -9,6 +9,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 
+import com.swoval.files.apple.FileEventsApi.ClosedFileEventsApiException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
@@ -197,7 +197,7 @@ trait FileCacheTest extends TestSuite {
             c.reg(dir, recursive = false)
             withTempFile(subdir) { f =>
               assert(f.exists)
-              subdir.setLastModifiedTime(2000)
+              subdir.setLastModifiedTime(3000)
               latch.waitFor(DEFAULT_TIMEOUT) {
                 c.ls(dir) === Seq(subdir)
               }
@@ -344,7 +344,7 @@ trait FileCacheTest extends TestSuite {
             }
           val lastModified = cachedFile.value.lastModified
           lastModified ==> file.lastModified
-          val updatedLastModified = 2000
+          val updatedLastModified = 3000
           file.setLastModifiedTime(updatedLastModified)
           latch.waitFor(DEFAULT_TIMEOUT) {
             val newCachedFile: Entry[LastModified] =

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
@@ -8,10 +8,9 @@ import com.swoval.files.Directory._
 import com.swoval.files.EntryOps._
 import com.swoval.files.FileCacheTest.FileCacheOps
 import com.swoval.files.test._
+import com.swoval.test.Implicits.executionContext
 import com.swoval.test._
 import utest._
-import Implicits.executionContext
-import com.swoval.files.SymlinkWatcher.OnLoop
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/files/shared/src/test/scala/com/swoval/files/NioDirectoryWatcherTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/NioDirectoryWatcherTest.scala
@@ -102,7 +102,9 @@ object NioDirectoryWatcherTest extends TestSuite {
       }.andThen {
         case Failure(_) =>
           if (overflowLatch.getCount > 0)
-            println(s"Overflow latch was not triggered ${overflowLatch.getCount}")
+            println(
+              s"Overflow latch was not triggered\noverflowLatch count: ${overflowLatch.getCount}" +
+                s"\nfileLatch count: ${fileLatch.getCount}")
           if (subdirLatch.getCount > 0) println("Subdirectory latch was not triggered")
           if (fileLatch.getCount > 0) println("File latch was not triggered")
       }

--- a/project/com/swoval/Build.scala
+++ b/project/com/swoval/Build.scala
@@ -430,6 +430,7 @@ object Build {
         }
         (unmanagedResources in Compile).value
       },
+      fork in Test := System.getProperty("swoval.fork.tests", "false") == "true",
       travisQuickListReflectionTest := {
         quickListReflectionTest
           .toTask(" com.swoval.files.NioQuickLister com.swoval.files.NativeQuickLister")


### PR DESCRIPTION
Occasionally the osx addmany test fails on travis. I think that this is
because of timeouts, not because of logic errors. It turns out that my
test reporting was not quite right because I was calling andThen after
the cache was closed. I wanted to know if events were still being
generated after the timeout, so I needed to move it to after the last
flatMap.