### PR TITLE
Refactor Entries

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/FileCacheImpl.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileCacheImpl.scala
@@ -478,7 +478,7 @@ private[files] class FileCacheImpl[T <: AnyRef](private val converter: Converter
                                             java.lang.Integer.MAX_VALUE
                                           else dir.getDepth - 1)
               val updates: Directory.Updates[T] =
-                dir.update(toUpdate, Directory.Entry.getKind(toUpdate, attrs))
+                dir.update(toUpdate, Directory.Entries.getKind(toUpdate, attrs))
               updates.observe(callbackObserver(callbacks))
             } catch {
               case e: IOException =>

--- a/files/js/src/main/scala/com/swoval/files/JsFileCache.scala
+++ b/files/js/src/main/scala/com/swoval/files/JsFileCache.scala
@@ -32,11 +32,11 @@ class JsFileCache[T <: AnyRef](converter: js.UndefOr[js.Function1[Path, T]],
         recursive.toOption.getOrElse(false),
         new EntryFilter[T] {
           override def accept(entry: Entry[_ <: T]): Boolean =
-            filter.fold(true)(_.apply(new JSEntry[T](entry.path.toString, entry.getValue)))
+            filter.fold(true)(_.apply(new JSEntry[T](entry.getPath.toString, entry.getValue)))
         }
       )
       .asScala
-      .map(e => new JSEntry[T](e.path.toString, e.getValue))
+      .map(e => new JSEntry[T](e.getPath.toString, e.getValue))
       .toJSArray
   }
   def register(path: String,
@@ -47,7 +47,7 @@ class JsFileCache[T <: AnyRef](converter: js.UndefOr[js.Function1[Path, T]],
   def addCallback(callback: js.Function1[JSEntry[T], Unit]): Int =
     inner.addCallback(new OnChange[T] {
       override def apply(entry: Entry[T]) =
-        callback.apply(new JSEntry[T](entry.path.toString, entry.getValue))
+        callback.apply(new JSEntry[T](entry.getPath.toString, entry.getValue))
     })
   def removeCallback(handle: Int): Unit = inner.removeObserver(handle)
   def close(): Unit = inner.close()

--- a/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
@@ -2,7 +2,7 @@
 
 package com.swoval.files
 
-import com.swoval.files.Directory.Entry.DIRECTORY
+import com.swoval.files.Directory.Entries.DIRECTORY
 import com.swoval.files.EntryFilters.AllPass
 import com.swoval.files.PathWatchers.Event.Create
 import com.swoval.files.PathWatchers.Event.Overflow

--- a/files/jvm/src/main/java/com/swoval/files/FileCacheImpl.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheImpl.java
@@ -522,7 +522,7 @@ class FileCacheImpl<T> implements FileCache<T> {
                     path,
                     dir.getDepth() == Integer.MAX_VALUE ? Integer.MAX_VALUE : dir.getDepth() - 1);
               final Directory.Updates<T> updates =
-                  dir.update(toUpdate, Directory.Entry.getKind(toUpdate, attrs));
+                  dir.update(toUpdate, Directory.Entries.getKind(toUpdate, attrs));
               updates.observe(callbackObserver(callbacks));
             } catch (final IOException e) {
               addCallback(callbacks, path, null, null, PathWatchers.Event.Error, e);

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -1,6 +1,6 @@
 package com.swoval.files;
 
-import static com.swoval.files.Directory.Entry.DIRECTORY;
+import static com.swoval.files.Directory.Entries.DIRECTORY;
 import static com.swoval.files.EntryFilters.AllPass;
 import static com.swoval.files.PathWatchers.Event.Create;
 import static com.swoval.files.PathWatchers.Event.Overflow;

--- a/files/shared/src/test/scala/com/swoval/files/EntryFilterTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/EntryFilterTest.scala
@@ -3,7 +3,7 @@ package com.swoval.files
 import java.io.File
 import java.nio.file.Path
 
-import com.swoval.files.Directory.{ Entry, EntryFilter }
+import com.swoval.files.Directory.{ Entries, Entry, EntryFilter }
 import com.swoval.test._
 import com.swoval.files.test._
 import com.swoval.files.test.FileBytes
@@ -16,7 +16,7 @@ object EntryFilterTest extends TestSuite {
   override val tests = Tests {
     'simple - withTempFileSync { f =>
       val filter: EntryFilter[Path] = EntryFilters.fromFileFilter((_: File) == f.toFile)
-      assert(filter.accept(new Entry(f, f)))
+      assert(filter.accept(Entries.get(f, Entries.FILE, identity(_: Path), f)))
     }
     'combined - withTempFileSync { f =>
       f.write("foo")
@@ -28,9 +28,9 @@ object EntryFilterTest extends TestSuite {
       val hashFilter: EntryFilter[FileBytes] =
         (_: Entry[FileBytes]).getValue.bytes.sameElements(bytes)
       val filter = hashFilter && base
-      assert(filter.accept(new Entry(f, FileBytes(f))))
+      assert(filter.accept(Entries.get(f, Entries.FILE, FileBytes(_: Path), f)))
       f.write("bar")
-      assert(!filter.accept(new Entry(f, FileBytes(f))))
+      assert(!filter.accept(Entries.get(f, Entries.FILE, FileBytes(_: Path), f)))
       compileError("base && hashFilter") // hashFilter is not a subtype of base
       ()
     }

--- a/files/shared/src/test/scala/com/swoval/files/package.scala
+++ b/files/shared/src/test/scala/com/swoval/files/package.scala
@@ -31,7 +31,7 @@ package object files extends PlatformFiles {
   }
   implicit class EntryFilterFunctionOps[T](val f: Entry[T] => Boolean) extends EntryFilter[T] {
     override def accept(cacheEntry: Entry[_ <: T]): Boolean =
-      f(new Entry[T](cacheEntry.getPath, cacheEntry.getValue, cacheEntry.getKind))
+      f(Entries.valid(cacheEntry.getPath, cacheEntry.getKind, cacheEntry.getValue))
   }
   implicit class OnChangeFunctionOps[T](val f: Entry[T] => Unit) extends OnChange[T] {
     override def apply(cacheEntry: Entry[T]): Unit = f(cacheEntry)

--- a/plugin/src/main/scala-sbt-0.13/com/swoval/watchservice/Compat.scala
+++ b/plugin/src/main/scala-sbt-0.13/com/swoval/watchservice/Compat.scala
@@ -3,7 +3,7 @@ package com.swoval.watchservice
 import java.io.File
 import java.nio.file._
 
-import com.swoval.files.Directory.{ Entry, EntryFilter }
+import com.swoval.files.Directory.{ Entries, Entry, EntryFilter }
 import com.swoval.files.{ Directory, FileCaches }
 import com.swoval.watchservice.CloseWatchPlugin.autoImport.closeWatchFileCache
 import sbt.Keys._
@@ -92,7 +92,7 @@ object Compat {
         case ((s, rf), f)                       => (s, rf :+ f)
       }
     val extra = rawFiles
-      .filterNot(f => sources.exists(_.filter.accept(new Entry(f.toPath, f.toPath))))
+      .filterNot(f => sources.exists(_.filter.accept(Entries.valid(f.toPath, f.toPath))))
       .map(new ExactFileSource(_))
     sources ++ extra
   }

--- a/plugin/src/main/scala-sbt-1.0/com/swoval/watchservice/Compat.scala
+++ b/plugin/src/main/scala-sbt-1.0/com/swoval/watchservice/Compat.scala
@@ -3,7 +3,7 @@ package com.swoval.watchservice
 import java.io.File
 import java.nio.file.{ Files, Path }
 
-import com.swoval.files.Directory.{ Entry, EntryFilter }
+import com.swoval.files.Directory.{ Entries, Entry, EntryFilter }
 import sbt.SourceWrapper._
 import sbt._
 import sbt.internal.BuildStructure
@@ -34,7 +34,7 @@ object Compat {
   private class PathFileFilter(val pathFilter: EntryFilter[Path]) extends FileFilter {
     override def accept(file: File): Boolean = pathFilter.accept {
       val p = file.toPath
-      new Entry(p, p)
+      Entries.valid(p, p)
     }
     override def equals(o: Any): Boolean = o match {
       case that: PathFileFilter => this.pathFilter == that.pathFilter

--- a/plugin/src/main/scala/com/swoval/watchservice/Filter.scala
+++ b/plugin/src/main/scala/com/swoval/watchservice/Filter.scala
@@ -3,7 +3,7 @@ package com.swoval.watchservice
 import java.io.File
 import java.nio.file.Path
 
-import com.swoval.files.Directory.{ Entry, EntryFilter }
+import com.swoval.files.Directory.{ Entries, Entry, EntryFilter }
 import com.swoval.watchservice.Compat.io._
 import com.swoval.watchservice.Filter._
 
@@ -40,7 +40,7 @@ class SourceFilter(override val base: Path, filter: EntryFilter[Path], override 
     with Compat.FileFilter {
   override def accept(cacheEntry: Entry[_ <: Path]): Boolean = apply(cacheEntry.getPath)
   override def accept(file: File): Boolean = apply(file.toPath)
-  def apply(p: Path): Boolean = p.startsWith(base) && filter.accept(new Entry(p, p))
+  def apply(p: Path): Boolean = p.startsWith(base) && filter.accept(Entries.valid(p, p))
   override lazy val toString: String = {
     val filterStr = Filter.show(filter, 0) match {
       case f if f.length > 80 =>


### PR DESCRIPTION
I didn't like the fact that I increased the object size by including the
IOException in the Entry so I refactored things so that Entry is now an
interface with two concrete implementations. By reworking it, I also
found areas in which it was possible for an unhandled IOException to
occur while creating an entry. To work around this, I replaced those
calls with calls to Entries.get which automatically handles the
IOExceptions.