### PR TITLE
Move CacheObservers and ObservableCache

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/CacheObservers.scala
+++ b/files/js/src/main/scala/com/swoval/files/CacheObservers.scala
@@ -114,8 +114,7 @@ class CacheObservers[T] extends CacheObserver[T] with AutoCloseable {
   }
 
   /**
-   * Remove an instance of [[CacheObserver]] that was previously added using
-   * [[com.swoval.files.Observers.addObserver]].
+   * Remove an instance of [[CacheObserver]] that was previously added using [[com.swoval.files.Observers.addObserver]].
    *
    * @param handle the handle to remove
    */

--- a/files/js/src/main/scala/com/swoval/files/CacheObservers.scala
+++ b/files/js/src/main/scala/com/swoval/files/CacheObservers.scala
@@ -3,7 +3,7 @@
 package com.swoval.files
 
 import com.swoval.files.FileTreeDataViews.Entry
-import com.swoval.files.FileTreeViews.CacheObserver
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import com.swoval.files.FileTreeViews.Observer
 import java.io.IOException
 import java.util.ArrayList
@@ -37,7 +37,7 @@ object CacheObservers {
 
 }
 
-class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseable {
+class CacheObservers[T] extends CacheObserver[T] with AutoCloseable {
 
   private val counter: AtomicInteger = new AtomicInteger(0)
 
@@ -57,11 +57,11 @@ class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseabl
   }
 
   override def onDelete(oldEntry: Entry[T]): Unit = {
-    var cbs: List[FileTreeViews.CacheObserver[T]] = null
+    var cbs: List[CacheObserver[T]] = null
     observers.synchronized {
       cbs = new ArrayList(observers.values)
     }
-    val it: Iterator[FileTreeViews.CacheObserver[T]] = cbs.iterator()
+    val it: Iterator[CacheObserver[T]] = cbs.iterator()
     while (it.hasNext) try it.next().onDelete(oldEntry)
     catch {
       case e: Exception => e.printStackTrace()
@@ -70,11 +70,11 @@ class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseabl
   }
 
   override def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit = {
-    var cbs: List[FileTreeViews.CacheObserver[T]] = null
+    var cbs: List[CacheObserver[T]] = null
     observers.synchronized {
       cbs = new ArrayList(observers.values)
     }
-    val it: Iterator[FileTreeViews.CacheObserver[T]] = cbs.iterator()
+    val it: Iterator[CacheObserver[T]] = cbs.iterator()
     while (it.hasNext) try it.next().onUpdate(oldEntry, newEntry)
     catch {
       case e: Exception => e.printStackTrace()
@@ -83,11 +83,11 @@ class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseabl
   }
 
   override def onError(exception: IOException): Unit = {
-    var cbs: List[FileTreeViews.CacheObserver[T]] = null
+    var cbs: List[CacheObserver[T]] = null
     observers.synchronized {
       cbs = new ArrayList(observers.values)
     }
-    val it: Iterator[FileTreeViews.CacheObserver[T]] = cbs.iterator()
+    val it: Iterator[CacheObserver[T]] = cbs.iterator()
     while (it.hasNext) it.next().onError(exception)
   }
 
@@ -105,7 +105,7 @@ class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseabl
     key
   }
 
-  def addCacheObserver(cacheObserver: FileTreeViews.CacheObserver[T]): Int = {
+  def addCacheObserver(cacheObserver: CacheObserver[T]): Int = {
     val key: Int = counter.getAndIncrement
     observers.synchronized {
       observers.put(key, cacheObserver)
@@ -114,7 +114,7 @@ class CacheObservers[T] extends FileTreeViews.CacheObserver[T] with AutoCloseabl
   }
 
   /**
-   * Remove an instance of [[FileTreeViews.CacheObserver]] that was previously added using
+   * Remove an instance of [[CacheObserver]] that was previously added using
    * [[com.swoval.files.Observers.addObserver]].
    *
    * @param handle the handle to remove

--- a/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
@@ -10,8 +10,8 @@ import com.swoval.functional.Filters.AllPass
 import com.swoval.files.FileTreeDataViews.Converter
 import com.swoval.files.FileTreeDataViews.Entry
 import com.swoval.files.FileTreeRepositoryImpl.Callback
-import com.swoval.files.FileTreeViews.CacheObserver
-import com.swoval.files.FileTreeViews.ObservableCache
+import com.swoval.files.FileTreeDataViews.CacheObserver
+import com.swoval.files.FileTreeDataViews.ObservableCache
 import com.swoval.files.FileTreeViews.Observer
 import com.swoval.files.PathWatchers.Event
 import com.swoval.files.PathWatchers.Event.Kind
@@ -423,8 +423,8 @@ class FileCacheDirectoryTree[T <: AnyRef](private val converter: Converter[T],
     }
 
   private def callbackObserver(callbacks: List[Callback],
-                               symlinks: List[TypedPath]): FileTreeViews.CacheObserver[T] =
-    new FileTreeViews.CacheObserver[T]() {
+                               symlinks: List[TypedPath]): CacheObserver[T] =
+    new CacheObserver[T]() {
       override def onCreate(newEntry: FileTreeDataViews.Entry[T]): Unit = {
         addCallback(callbacks, symlinks, newEntry, null, newEntry, Create, null)
       }

--- a/files/js/src/main/scala/com/swoval/files/FileTreeDataViews.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeDataViews.scala
@@ -2,6 +2,7 @@
 
 package com.swoval.files
 
+import com.swoval.files.FileTreeViews.Observable
 import com.swoval.functional.Either
 import com.swoval.functional.Filters
 import java.io.IOException
@@ -36,9 +37,11 @@ object FileTreeDataViews {
    * with each value.
    *
    * @param path the path to monitor
+   * @param converter computes the data value for each path found in the directory
    * @param depth sets how the limit for how deep to traverse the children of this directory
    * @param followLinks sets whether or not to treat symbolic links whose targets as directories or
    *     files
+   * @tparam T the data type for this view
    * @return a directory whose entries just contain the path itself.
    */
   def cached[T <: AnyRef](path: Path,
@@ -78,6 +81,61 @@ object FileTreeDataViews {
      * @return the converted value
      */
     def apply(path: TypedPath): R
+
+  }
+
+  /**
+   * Provides callbacks to run when different types of file events are detected by the cache.
+   *
+   * @tparam T the type for the [[Entry]] data
+   */
+  trait CacheObserver[T] {
+
+    /**
+     * Callback to fire when a new path is created.
+     *
+     * @param newEntry the [[Entry]] for the newly created file
+     */
+    def onCreate(newEntry: Entry[T]): Unit
+
+    /**
+     * Callback to fire when a path is deleted.
+     *
+     * @param oldEntry the [[Entry]] for the deleted.
+     */
+    def onDelete(oldEntry: Entry[T]): Unit
+
+    /**
+     * Callback to fire when a path is modified.
+     *
+     * @param oldEntry the [[Entry]] for the updated path
+     * @param newEntry the [[Entry]] for the deleted path
+     */
+    def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit
+
+    /**
+     * Callback to fire when an error is encountered generating while updating a path.
+     *
+     * @param exception The exception thrown by the computation
+     */
+    def onError(exception: IOException): Unit
+
+  }
+
+  /**
+   * A file tree cache that can be monitored for events.
+   *
+   * @tparam T the type of data stored in the cache.
+   */
+  trait ObservableCache[T] extends Observable[Entry[T]] {
+
+    /**
+     * Add an observer of cache events.
+     *
+     * @param observer the observer to add
+     * @return the handle to the observer.
+     */
+    def addCacheObserver(observer: CacheObserver[T]): Int
 
   }
 

--- a/files/js/src/main/scala/com/swoval/files/FileTreeRepository.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeRepository.scala
@@ -4,7 +4,7 @@ package com.swoval.files
 
 import com.swoval.files.FileTreeDataViews.Converter
 import com.swoval.files.FileTreeDataViews.Entry
-import com.swoval.files.FileTreeViews.ObservableCache
+import com.swoval.files.FileTreeDataViews.ObservableCache
 import com.swoval.functional.Either
 import java.io.IOException
 import java.nio.file.Path

--- a/files/js/src/main/scala/com/swoval/files/FileTreeRepositoryImpl.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeRepositoryImpl.scala
@@ -3,7 +3,7 @@
 package com.swoval.files
 
 import com.swoval.files.FileTreeDataViews.Entry
-import com.swoval.files.FileTreeViews.CacheObserver
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import com.swoval.files.FileTreeViews.Observer
 import com.swoval.functional.Either
 import com.swoval.functional.Filter

--- a/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
@@ -2,6 +2,7 @@
 
 package com.swoval.files
 
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import com.swoval.files.FileTreeDataViews.Converter
 import com.swoval.files.FileTreeDataViews.Entry
 import com.swoval.functional.Filter
@@ -9,7 +10,6 @@ import com.swoval.functional.Filters
 import java.io.IOException
 import java.nio.file.Path
 import java.util.ArrayList
-import java.util.Collections
 import java.util.Iterator
 import java.util.List
 
@@ -125,44 +125,6 @@ object FileTreeViews {
 
   }
 
-  /**
-   * Provides callbacks to run when different types of file events are detected by the cache.
-   *
-   * @tparam T the type for the [[FileTreeDataViews.Entry]] data
-   */
-  trait CacheObserver[T] {
-
-    /**
-     * Callback to fire when a new path is created.
-     *
-     * @param newEntry the [[FileTreeDataViews.Entry]] for the newly created file
-     */
-    def onCreate(newEntry: Entry[T]): Unit
-
-    /**
-     * Callback to fire when a path is deleted.
-     *
-     * @param oldEntry the [[Entry]] for the deleted.
-     */
-    def onDelete(oldEntry: Entry[T]): Unit
-
-    /**
-     * Callback to fire when a path is modified.
-     *
-     * @param oldEntry the [[Entry]] for the updated path
-     * @param newEntry the [[Entry]] for the deleted path
-     */
-    def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit
-
-    /**
-     * Callback to fire when an error is encountered generating while updating a path.
-     *
-     * @param exception The exception thrown by the computation
-     */
-    def onError(exception: IOException): Unit
-
-  }
-
   trait Observable[T] {
 
     /**
@@ -179,23 +141,6 @@ object FileTreeViews {
      * @param handle the handle that was returned by addObserver
      */
     def removeObserver(handle: Int): Unit
-
-  }
-
-  /**
-   * A file tree cache that can be monitored for events.
-   *
-   * @tparam T the type of data stored in the cache.
-   */
-  trait ObservableCache[T] extends Observable[Entry[T]] {
-
-    /**
-     * Add an observer of cache events.
-     *
-     * @param observer the observer to add
-     * @return the handle to the observer.
-     */
-    def addCacheObserver(observer: CacheObserver[T]): Int
 
   }
 

--- a/files/js/src/main/scala/com/swoval/files/MapOps.scala
+++ b/files/js/src/main/scala/com/swoval/files/MapOps.scala
@@ -3,6 +3,7 @@
 package com.swoval.files
 
 import java.util.Map.Entry
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import java.nio.file.Path
 import java.util.ArrayList
 import java.util.HashMap
@@ -14,7 +15,7 @@ object MapOps {
 
   def diffDirectoryEntries[T](oldEntries: List[FileTreeDataViews.Entry[T]],
                               newEntries: List[FileTreeDataViews.Entry[T]],
-                              cacheObserver: FileTreeViews.CacheObserver[T]): Unit = {
+                              cacheObserver: CacheObserver[T]): Unit = {
     val oldMap: Map[Path, FileTreeDataViews.Entry[T]] =
       new HashMap[Path, FileTreeDataViews.Entry[T]]()
     val oldIterator: Iterator[FileTreeDataViews.Entry[T]] =
@@ -36,7 +37,7 @@ object MapOps {
 
   def diffDirectoryEntries[K, V](oldMap: Map[K, FileTreeDataViews.Entry[V]],
                                  newMap: Map[K, FileTreeDataViews.Entry[V]],
-                                 cacheObserver: FileTreeViews.CacheObserver[V]): Unit = {
+                                 cacheObserver: CacheObserver[V]): Unit = {
     val newIterator: Iterator[Entry[K, FileTreeDataViews.Entry[V]]] =
       new ArrayList(newMap.entrySet()).iterator()
     val oldIterator: Iterator[Entry[K, FileTreeDataViews.Entry[V]]] =

--- a/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
@@ -73,7 +73,9 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
       }
 
       override def onDelete(oldEntry: FileTreeDataViews.Entry[WatchedDirectory]): Unit = {
-        if (oldEntry.getValue.isRight) oldEntry.getValue.get.close()
+        if (oldEntry.getValue.isRight) {
+          oldEntry.getValue.get.close()
+        }
         events.add(new Event(oldEntry, Delete))
       }
 
@@ -243,6 +245,7 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
               }
             }
           }
+          rootDirectories.remove(dir.getPath)
         }
       } finally rootDirectories.unlock()
     }
@@ -352,6 +355,11 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
                 either.get.close()
               }
               events.add(new Event(Entries.setExists(entry, false), Kind.Delete))
+            }
+            val parent: CachedDirectory[WatchedDirectory] =
+              find(event.getPath.getParent, new ArrayList[Path]())
+            if (parent != null) {
+              update(parent, parent.getEntry, events)
             }
             if (isRoot) {
               rootDirectories.remove(root.getPath)

--- a/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
@@ -218,7 +218,7 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
     if (rootDirectories.lock()) {
       try {
         val dir: CachedDirectory[WatchedDirectory] =
-          rootDirectories.get(path.getRoot)
+          find(path, new ArrayList[Path]())
         if (dir != null) {
           val depth: Int = dir.getPath.relativize(path).getNameCount
           val toRemove: List[FileTreeDataViews.Entry[WatchedDirectory]] =

--- a/files/js/src/main/scala/com/swoval/files/Observers.scala
+++ b/files/js/src/main/scala/com/swoval/files/Observers.scala
@@ -65,8 +65,7 @@ class Observers[T] extends FileTreeViews.Observer[T] with AutoCloseable {
   }
 
   /**
-   * Remove an instance of [[CacheObserver]] that was previously added using
-   * [[com.swoval.files.Observers.addObserver]].
+   * Remove an instance of [[CacheObserver]] that was previously added using [[com.swoval.files.Observers.addObserver]].
    *
    * @param handle the handle to remove
    */

--- a/files/js/src/main/scala/com/swoval/files/Observers.scala
+++ b/files/js/src/main/scala/com/swoval/files/Observers.scala
@@ -2,6 +2,7 @@
 
 package com.swoval.files
 
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import com.swoval.files.FileTreeViews.Observer
 import java.util.ArrayList
 import java.util.Iterator
@@ -64,7 +65,7 @@ class Observers[T] extends FileTreeViews.Observer[T] with AutoCloseable {
   }
 
   /**
-   * Remove an instance of [[FileTreeViews.CacheObserver]] that was previously added using
+   * Remove an instance of [[CacheObserver]] that was previously added using
    * [[com.swoval.files.Observers.addObserver]].
    *
    * @param handle the handle to remove

--- a/files/jvm/src/main/java/com/swoval/files/CacheObservers.java
+++ b/files/jvm/src/main/java/com/swoval/files/CacheObservers.java
@@ -1,7 +1,7 @@
 package com.swoval.files;
 
 import com.swoval.files.FileTreeDataViews.Entry;
-import com.swoval.files.FileTreeViews.CacheObserver;
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import com.swoval.files.FileTreeViews.Observer;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable {
+class CacheObservers<T> implements CacheObserver<T>, AutoCloseable {
   private final AtomicInteger counter = new AtomicInteger(0);
   private final Map<Integer, CacheObserver<T>> observers = new LinkedHashMap<>();
 
@@ -33,11 +33,11 @@ class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable
 
   @Override
   public void onDelete(final Entry<T> oldEntry) {
-    final List<FileTreeViews.CacheObserver<T>> cbs;
+    final List<CacheObserver<T>> cbs;
     synchronized (observers) {
       cbs = new ArrayList<>(observers.values());
     }
-    final Iterator<FileTreeViews.CacheObserver<T>> it = cbs.iterator();
+    final Iterator<CacheObserver<T>> it = cbs.iterator();
     while (it.hasNext()) {
       try {
         it.next().onDelete(oldEntry);
@@ -49,11 +49,11 @@ class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable
 
   @Override
   public void onUpdate(final Entry<T> oldEntry, final Entry<T> newEntry) {
-    final List<FileTreeViews.CacheObserver<T>> cbs;
+    final List<CacheObserver<T>> cbs;
     synchronized (observers) {
       cbs = new ArrayList<>(observers.values());
     }
-    final Iterator<FileTreeViews.CacheObserver<T>> it = cbs.iterator();
+    final Iterator<CacheObserver<T>> it = cbs.iterator();
     while (it.hasNext()) {
       try {
         it.next().onUpdate(oldEntry, newEntry);
@@ -65,11 +65,11 @@ class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable
 
   @Override
   public void onError(IOException exception) {
-    final List<FileTreeViews.CacheObserver<T>> cbs;
+    final List<CacheObserver<T>> cbs;
     synchronized (observers) {
       cbs = new ArrayList<>(observers.values());
     }
-    final Iterator<FileTreeViews.CacheObserver<T>> it = cbs.iterator();
+    final Iterator<CacheObserver<T>> it = cbs.iterator();
     while (it.hasNext()) it.next().onError(exception);
   }
 
@@ -88,7 +88,7 @@ class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable
     return key;
   }
 
-  int addCacheObserver(final FileTreeViews.CacheObserver<T> cacheObserver) {
+  int addCacheObserver(final CacheObserver<T> cacheObserver) {
     final int key = counter.getAndIncrement();
     synchronized (observers) {
       observers.put(key, cacheObserver);
@@ -97,8 +97,8 @@ class CacheObservers<T> implements FileTreeViews.CacheObserver<T>, AutoCloseable
   }
 
   /**
-   * Remove an instance of {@link FileTreeViews.CacheObserver} that was previously added using
-   * {@link com.swoval.files.Observers#addObserver(FileTreeViews.Observer)}.
+   * Remove an instance of {@link CacheObserver} that was previously added using {@link
+   * com.swoval.files.Observers#addObserver(FileTreeViews.Observer)}.
    *
    * @param handle the handle to remove
    */

--- a/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
@@ -9,8 +9,8 @@ import static com.swoval.functional.Filters.AllPass;
 import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeDataViews.Entry;
 import com.swoval.files.FileTreeRepositoryImpl.Callback;
-import com.swoval.files.FileTreeViews.CacheObserver;
-import com.swoval.files.FileTreeViews.ObservableCache;
+import com.swoval.files.FileTreeDataViews.CacheObserver;
+import com.swoval.files.FileTreeDataViews.ObservableCache;
 import com.swoval.files.FileTreeViews.Observer;
 import com.swoval.files.PathWatchers.Event;
 import com.swoval.files.PathWatchers.Event.Kind;
@@ -462,9 +462,9 @@ class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<
     }
   }
 
-  private FileTreeViews.CacheObserver<T> callbackObserver(
+  private CacheObserver<T> callbackObserver(
       final List<Callback> callbacks, final List<TypedPath> symlinks) {
-    return new FileTreeViews.CacheObserver<T>() {
+    return new CacheObserver<T>() {
       @Override
       public void onCreate(final FileTreeDataViews.Entry<T> newEntry) {
         addCallback(callbacks, symlinks, newEntry, null, newEntry, Create, null);

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeDataViews.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeDataViews.java
@@ -1,5 +1,6 @@
 package com.swoval.files;
 
+import com.swoval.files.FileTreeViews.Observable;
 import com.swoval.functional.Either;
 import com.swoval.functional.Filters;
 import java.io.IOException;
@@ -80,5 +81,57 @@ public class FileTreeDataViews {
      * @throws IOException when the value can't be computed
      */
     R apply(TypedPath path) throws IOException;
+  }
+
+  /**
+   * Provides callbacks to run when different types of file events are detected by the cache.
+   *
+   * @param <T> the type for the {@link Entry} data
+   */
+  public interface CacheObserver<T> {
+
+    /**
+     * Callback to fire when a new path is created.
+     *
+     * @param newEntry the {@link Entry} for the newly created file
+     */
+    void onCreate(final Entry<T> newEntry);
+
+    /**
+     * Callback to fire when a path is deleted.
+     *
+     * @param oldEntry the {@link Entry} for the deleted.
+     */
+    void onDelete(final Entry<T> oldEntry);
+
+    /**
+     * Callback to fire when a path is modified.
+     *
+     * @param oldEntry the {@link Entry} for the updated path
+     * @param newEntry the {@link Entry} for the deleted path
+     */
+    void onUpdate(final Entry<T> oldEntry, final Entry<T> newEntry);
+
+    /**
+     * Callback to fire when an error is encountered generating while updating a path.
+     *
+     * @param exception The exception thrown by the computation
+     */
+    void onError(final IOException exception);
+  }
+
+  /**
+   * A file tree cache that can be monitored for events.
+   *
+   * @param <T> the type of data stored in the cache.
+   */
+  public interface ObservableCache<T> extends Observable<Entry<T>> {
+    /**
+     * Add an observer of cache events.
+     *
+     * @param observer the observer to add
+     * @return the handle to the observer.
+     */
+    int addCacheObserver(final CacheObserver<T> observer);
   }
 }

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepository.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepository.java
@@ -2,7 +2,7 @@ package com.swoval.files;
 
 import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeDataViews.Entry;
-import com.swoval.files.FileTreeViews.ObservableCache;
+import com.swoval.files.FileTreeDataViews.ObservableCache;
 import com.swoval.functional.Either;
 import java.io.IOException;
 import java.nio.file.Path;

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.swoval.files;
 
 import com.swoval.files.FileTreeDataViews.Entry;
-import com.swoval.files.FileTreeViews.CacheObserver;
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import com.swoval.files.FileTreeViews.Observer;
 import com.swoval.functional.Either;
 import com.swoval.functional.Filter;

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
@@ -1,5 +1,6 @@
 package com.swoval.files;
 
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeDataViews.Entry;
 import com.swoval.functional.Filter;
@@ -7,7 +8,6 @@ import com.swoval.functional.Filters;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -138,42 +138,6 @@ public class FileTreeViews {
      */
     void onNext(final T t);
   }
-  /**
-   * Provides callbacks to run when different types of file events are detected by the cache.
-   *
-   * @param <T> the type for the {@link FileTreeDataViews.Entry} data
-   */
-  public interface CacheObserver<T> {
-
-    /**
-     * Callback to fire when a new path is created.
-     *
-     * @param newEntry the {@link FileTreeDataViews.Entry} for the newly created file
-     */
-    void onCreate(final Entry<T> newEntry);
-
-    /**
-     * Callback to fire when a path is deleted.
-     *
-     * @param oldEntry the {@link Entry} for the deleted.
-     */
-    void onDelete(final Entry<T> oldEntry);
-
-    /**
-     * Callback to fire when a path is modified.
-     *
-     * @param oldEntry the {@link Entry} for the updated path
-     * @param newEntry the {@link Entry} for the deleted path
-     */
-    void onUpdate(final Entry<T> oldEntry, final Entry<T> newEntry);
-
-    /**
-     * Callback to fire when an error is encountered generating while updating a path.
-     *
-     * @param exception The exception thrown by the computation
-     */
-    void onError(final IOException exception);
-  }
 
   public interface Observable<T> {
 
@@ -191,21 +155,6 @@ public class FileTreeViews {
      * @param handle the handle that was returned by addObserver
      */
     void removeObserver(final int handle);
-  }
-
-  /**
-   * A file tree cache that can be monitored for events.
-   *
-   * @param <T> the type of data stored in the cache.
-   */
-  public interface ObservableCache<T> extends Observable<Entry<T>> {
-    /**
-     * Add an observer of cache events.
-     *
-     * @param observer the observer to add
-     * @return the handle to the observer.
-     */
-    int addCacheObserver(final CacheObserver<T> observer);
   }
 
   static class Updates<T> implements CacheObserver<T> {

--- a/files/jvm/src/main/java/com/swoval/files/MacOSXWatchService.java
+++ b/files/jvm/src/main/java/com/swoval/files/MacOSXWatchService.java
@@ -200,7 +200,7 @@ class MacOSXWatchService implements RegisterableWatchService {
             }
           }
           result = new MacOSXWatchKey(realPath, queueSize, handle, kinds);
-          if (registered.put(realPath, new WatchKey(handle, result)) == null) {
+          if (registered.put(realPath, new WatchKey(handle, result)) != null) {
             result.cancel();
             throw new ClosedWatchServiceException();
           }

--- a/files/jvm/src/main/java/com/swoval/files/MapOps.java
+++ b/files/jvm/src/main/java/com/swoval/files/MapOps.java
@@ -2,6 +2,7 @@ package com.swoval.files;
 
 import static java.util.Map.Entry;
 
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +21,7 @@ class MapOps {
   static <T> void diffDirectoryEntries(
       final List<FileTreeDataViews.Entry<T>> oldEntries,
       final List<FileTreeDataViews.Entry<T>> newEntries,
-      final FileTreeViews.CacheObserver<T> cacheObserver) {
+      final CacheObserver<T> cacheObserver) {
     final Map<Path, FileTreeDataViews.Entry<T>> oldMap = new HashMap<>();
     final Iterator<FileTreeDataViews.Entry<T>> oldIterator = oldEntries.iterator();
     while (oldIterator.hasNext()) {
@@ -39,7 +40,7 @@ class MapOps {
   static <K, V> void diffDirectoryEntries(
       final Map<K, FileTreeDataViews.Entry<V>> oldMap,
       final Map<K, FileTreeDataViews.Entry<V>> newMap,
-      final FileTreeViews.CacheObserver<V> cacheObserver) {
+      final CacheObserver<V> cacheObserver) {
     final Iterator<Entry<K, FileTreeDataViews.Entry<V>>> newIterator =
         new ArrayList<>(newMap.entrySet()).iterator();
     final Iterator<Entry<K, FileTreeDataViews.Entry<V>>> oldIterator =

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -244,7 +244,7 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
     directoryRegistry.removeDirectory(path);
     if (rootDirectories.lock()) {
       try {
-        final CachedDirectory<WatchedDirectory> dir = rootDirectories.get(path.getRoot());
+        final CachedDirectory<WatchedDirectory> dir = find(path, new ArrayList<Path>());
         if (dir != null) {
           final int depth = dir.getPath().relativize(path).getNameCount();
           List<FileTreeDataViews.Entry<WatchedDirectory>> toRemove =
@@ -268,6 +268,7 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
               }
             }
           }
+          rootDirectories.remove(dir.getPath());
         }
       } finally {
         rootDirectories.unlock();

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -65,7 +65,9 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
 
       @Override
       public void onDelete(final FileTreeDataViews.Entry<WatchedDirectory> oldEntry) {
-        if (oldEntry.getValue().isRight()) oldEntry.getValue().get().close();
+        if (oldEntry.getValue().isRight()) {
+          oldEntry.getValue().get().close();
+        }
         events.add(new Event(oldEntry, Delete));
       }
 
@@ -381,6 +383,11 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
                   either.get().close();
                 }
                 events.add(new Event(Entries.setExists(entry, false), Kind.Delete));
+              }
+              final CachedDirectory<WatchedDirectory> parent =
+                  find(event.getPath().getParent(), new ArrayList<Path>());
+              if (parent != null) {
+                update(parent, parent.getEntry(), events);
               }
               if (isRoot) {
                 rootDirectories.remove(root.getPath());

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -6,6 +6,7 @@ import static com.swoval.files.PathWatchers.Event.Kind.Modify;
 import static com.swoval.functional.Filters.AllPass;
 import static java.util.Map.Entry;
 
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeViews.Observer;
 import com.swoval.files.PathWatchers.Event;
@@ -34,9 +35,8 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
   private final DirectoryRegistry directoryRegistry;
   private final Converter<WatchedDirectory> converter;
 
-  private FileTreeViews.CacheObserver<WatchedDirectory> updateCacheObserver(
-      final List<Event> events) {
-    return new FileTreeViews.CacheObserver<WatchedDirectory>() {
+  private CacheObserver<WatchedDirectory> updateCacheObserver(final List<Event> events) {
+    return new CacheObserver<WatchedDirectory>() {
       @Override
       @SuppressWarnings("EmptyCatchBlock")
       public void onCreate(final FileTreeDataViews.Entry<WatchedDirectory> newEntry) {

--- a/files/jvm/src/main/java/com/swoval/files/Observers.java
+++ b/files/jvm/src/main/java/com/swoval/files/Observers.java
@@ -1,5 +1,6 @@
 package com.swoval.files;
 
+import com.swoval.files.FileTreeDataViews.CacheObserver;
 import com.swoval.files.FileTreeViews.Observer;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -66,8 +67,8 @@ class Observers<T> implements FileTreeViews.Observer<T>, AutoCloseable {
   }
 
   /**
-   * Remove an instance of {@link FileTreeViews.CacheObserver} that was previously added using
-   * {@link com.swoval.files.Observers#addObserver(FileTreeViews.Observer)}.
+   * Remove an instance of {@link CacheObserver} that was previously added using {@link
+   * com.swoval.files.Observers#addObserver(FileTreeViews.Observer)}.
    *
    * @param handle the handle to remove
    */

--- a/files/jvm/src/main/java/com/swoval/files/package-info.java
+++ b/files/jvm/src/main/java/com/swoval/files/package-info.java
@@ -4,7 +4,7 @@
  * {@link com.swoval.files.FileTreeRepository} generates an in memory cache of a set of directories
  * that can be listed. The cache can store arbitrary user data that is returned to the user whenever
  * the cache is listed or fires a callback (see {@link
- * com.swoval.files.FileTreeViews.CacheObserver}).
+ * com.swoval.files.FileTreeDataViews.CacheObserver}).
  *
  * <p>The implementation of all of the classes in this package uses only apis and code constructs
  * that can be translated by <a href="https://github.com/timowest/scalagen">scalagen</a>. This can

--- a/files/shared/src/test/scala/com/swoval/files/BasicFileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/BasicFileCacheTest.scala
@@ -246,7 +246,7 @@ trait BasicFileCacheTest extends TestSuite with FileCacheTest {
           FileCacheTest.getCached[LastModified](
             false,
             LastModified(_: TypedPath),
-            new FileTreeViews.CacheObserver[LastModified] {
+            new FileTreeDataViews.CacheObserver[LastModified] {
               override def onCreate(newEntry: Entry[LastModified]): Unit = {}
 
               override def onDelete(oldEntry: Entry[LastModified]): Unit = {}
@@ -312,7 +312,7 @@ trait BasicFileCacheTest extends TestSuite with FileCacheTest {
         val deletionLatch = new CountDownLatch(1)
         val newFileLatch = new CountDownLatch(1)
         val newFile = dir.resolve("new-file")
-        val observer = new FileTreeViews.CacheObserver[Path] {
+        val observer = new FileTreeDataViews.CacheObserver[Path] {
           override def onCreate(newEntry: Entry[Path]): Unit = {
             if (newEntry.getPath == newFile) newFileLatch.countDown()
           }

--- a/files/shared/src/test/scala/com/swoval/files/CachedFileTreeViewTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/CachedFileTreeViewTest.scala
@@ -4,9 +4,9 @@ import java.io.IOException
 import java.nio.file.{ Files, Path }
 import java.util
 
-import FileTreeDataViews.Entry
+import FileTreeDataViews.{ CacheObserver, Entry }
 import com.swoval.files.FileTreeViewTest.RepositoryOps
-import com.swoval.files.FileTreeViews.{ CacheObserver, Observer }
+import com.swoval.files.FileTreeViews.Observer
 import com.swoval.files.test._
 import com.swoval.functional.{ Consumer, Filter }
 import com.swoval.functional.Filters.AllPass

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheOverflowTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheOverflowTest.scala
@@ -20,7 +20,7 @@ import scala.util.{ Failure, Success, Try }
 trait FileCacheOverflowTest extends TestSuite with FileCacheTest {
   def getBounded[T <: AnyRef](
       converter: FileTreeDataViews.Converter[T],
-      cacheObserver: FileTreeViews.CacheObserver[T]
+      cacheObserver: FileTreeDataViews.CacheObserver[T]
   ): FileTreeRepository[T] =
     FileCacheTest.get[T](
       false,
@@ -170,7 +170,7 @@ trait FileCacheOverflowTest extends TestSuite with FileCacheTest {
 object FileCacheOverflowTest extends FileCacheOverflowTest with DefaultFileCacheTest {
   override def getBounded[T <: AnyRef](
       converter: FileTreeDataViews.Converter[T],
-      cacheObserver: FileTreeViews.CacheObserver[T]): FileTreeRepository[T] =
+      cacheObserver: FileTreeDataViews.CacheObserver[T]): FileTreeRepository[T] =
     if (Platform.isMac) FileCacheTest.getCached(false, converter, cacheObserver)
     else super.getBounded(converter, cacheObserver)
   val tests = testsImpl

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheSymlinkTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheSymlinkTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import TestHelpers._
 import EntryOps._
-import com.swoval.files.FileTreeViews.CacheObserver
+import com.swoval.files.FileTreeDataViews.CacheObserver
 
 trait FileCacheSymlinkTest extends TestSuite with FileCacheTest {
   val testsImpl = Tests {
@@ -221,7 +221,7 @@ trait FileCacheSymlinkTest extends TestSuite with FileCacheTest {
           usingAsync(FileCacheTest.getCached[Path](
             true,
             identity,
-            new FileTreeViews.CacheObserver[Path] {
+            new FileTreeDataViews.CacheObserver[Path] {
               override def onCreate(newEntry: Entry[Path]): Unit = {}
 
               override def onDelete(oldEntry: Entry[Path]): Unit = {
@@ -311,7 +311,7 @@ trait FileCacheSymlinkTest extends TestSuite with FileCacheTest {
             usingAsync(FileCacheTest.getCached[Path](
               true,
               identity,
-              new FileTreeViews.CacheObserver[Path] {
+              new FileTreeDataViews.CacheObserver[Path] {
                 override def onCreate(newEntry: Entry[Path]): Unit = {}
 
                 override def onDelete(oldEntry: Entry[Path]): Unit = {}
@@ -350,7 +350,7 @@ trait FileCacheSymlinkTest extends TestSuite with FileCacheTest {
             usingAsync(FileCacheTest.getCached[Path](
               true,
               identity,
-              new FileTreeViews.CacheObserver[Path] {
+              new FileTreeDataViews.CacheObserver[Path] {
                 override def onCreate(newEntry: Entry[Path]): Unit = {}
 
                 override def onDelete(oldEntry: Entry[Path]): Unit = {

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.nio.file.Path
 
 import com.swoval.files.FileTreeDataViews.{ Converter, Entry }
-import com.swoval.files.FileTreeViews.CacheObserver
+import com.swoval.files.FileTreeDataViews.CacheObserver
 import com.swoval.files.PathWatchers.Event
 import com.swoval.files.TestHelpers._
 import com.swoval.files.test._
@@ -41,7 +41,7 @@ object FileCacheTest {
     res.addCacheObserver(cacheObserver)
     res
   }
-  class LoopCacheObserver(val latch: CountDownLatch) extends FileTreeViews.CacheObserver[Path] {
+  class LoopCacheObserver(val latch: CountDownLatch) extends FileTreeDataViews.CacheObserver[Path] {
     override def onCreate(newEntry: Entry[Path]): Unit = {}
     override def onDelete(oldEntry: Entry[Path]): Unit = {}
     override def onUpdate(oldEntry: Entry[Path], newEntry: Entry[Path]): Unit = {}
@@ -71,7 +71,7 @@ object FileCacheTest {
   private[files] def get[T <: AnyRef](
       followLinks: Boolean,
       converter: FileTreeDataViews.Converter[T],
-      cacheObserver: FileTreeViews.CacheObserver[T],
+      cacheObserver: FileTreeDataViews.CacheObserver[T],
       watcherFactory: (DirectoryRegistry) => PathWatcher[PathWatchers.Event])
     : FileTreeRepository[T] = {
     val symlinkWatcher =

--- a/files/shared/src/test/scala/com/swoval/files/package.scala
+++ b/files/shared/src/test/scala/com/swoval/files/package.scala
@@ -4,8 +4,8 @@ package files
 import java.io.{ File, FileFilter, IOException }
 import java.nio.file.Path
 
-import com.swoval.files.FileTreeDataViews.{ Converter, Entry }
-import com.swoval.files.FileTreeViews.{ CacheObserver, Observer }
+import com.swoval.files.FileTreeDataViews.{ CacheObserver, Converter, Entry }
+import com.swoval.files.FileTreeViews.Observer
 import com.swoval.files.test.platform.Bool
 import com.swoval.functional.{ Consumer, Filter }
 import com.swoval.test._
@@ -25,8 +25,8 @@ object TestHelpers extends PlatformFiles {
       oncreate: Entry[T] => Unit,
       onupdate: (Entry[T], Entry[T]) => Unit,
       ondelete: Entry[T] => Unit,
-      onerror: IOException => Unit = _ => {}): FileTreeViews.CacheObserver[T] =
-    new FileTreeViews.CacheObserver[T] {
+      onerror: IOException => Unit = _ => {}): FileTreeDataViews.CacheObserver[T] =
+    new FileTreeDataViews.CacheObserver[T] {
       override def onCreate(newEntry: Entry[T]): Unit = oncreate(newEntry)
 
       override def onDelete(oldEntry: Entry[T]): Unit = ondelete(oldEntry)
@@ -37,7 +37,7 @@ object TestHelpers extends PlatformFiles {
       override def onError(exception: IOException): Unit = onerror(exception)
     }
 
-  def getObserver[T <: AnyRef](onUpdate: Entry[T] => Unit): FileTreeViews.CacheObserver[T] =
+  def getObserver[T <: AnyRef](onUpdate: Entry[T] => Unit): FileTreeDataViews.CacheObserver[T] =
     getObserver[T](onUpdate, (_: Entry[T], e: Entry[T]) => onUpdate(e), onUpdate)
 
   implicit class PathWatcherOps[T](val watcher: PathWatcher[T]) extends AnyVal {
@@ -85,7 +85,7 @@ object TestHelpers extends PlatformFiles {
     override def onNext(t: PathWatchers.Event): Unit = f(t)
   }
   implicit class CacheObserverFunctionOps[T](val f: Entry[T] => Unit)
-      extends FileTreeViews.CacheObserver[T] {
+      extends FileTreeDataViews.CacheObserver[T] {
     override def onCreate(newCachedPath: Entry[T]): Unit = f(newCachedPath)
 
     override def onDelete(oldCachedPath: Entry[T]): Unit = f(oldCachedPath)


### PR DESCRIPTION
It didn't make sense to have these in FileTreeViews given the existence
of FileTreeDataViews.