### PR TITLE
Don't exclude symbolic links when followLinks is true

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/FileTreeRepositories.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeRepositories.scala
@@ -32,7 +32,7 @@ object FileTreeRepositories {
     val tree: FileCacheDirectoryTree[T] =
       new FileCacheDirectoryTree[T](converter, callbackExecutor, symlinkWatcher)
     val pathWatcher: PathWatcher[PathWatchers.Event] =
-      PathWatchers.get(false, tree.readOnlyDirectoryRegistry())
+      PathWatchers.get(followLinks, tree.readOnlyDirectoryRegistry())
     pathWatcher.addObserver(new Observer[Event]() {
       override def onError(t: Throwable): Unit = {}
 

--- a/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
@@ -33,7 +33,8 @@ class RootDirectories extends LockableMap[Path, CachedDirectory[WatchedDirectory
  Provides a PathWatcher that is backed by a [[java.nio.file.WatchService]].
  */
 class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
-                     watchService: RegisterableWatchService)
+                     watchService: RegisterableWatchService,
+                     private val followLinks: Boolean)
     extends PathWatcher[PathWatchers.Event]
     with AutoCloseable {
 
@@ -188,8 +189,8 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
           java.lang.Integer.MAX_VALUE,
           new Filter[TypedPath]() {
             override def accept(typedPath: TypedPath): Boolean =
-              typedPath.isDirectory && !typedPath.isSymbolicLink && directoryRegistry
-                .acceptPrefix(typedPath.getPath)
+              typedPath.isDirectory && (followLinks || !typedPath.isSymbolicLink) &&
+                directoryRegistry.acceptPrefix(typedPath.getPath)
           },
           FileTreeViews.getDefault(false)
         ).init()

--- a/files/js/src/main/scala/com/swoval/files/PlatformWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/PlatformWatcher.scala
@@ -7,7 +7,7 @@ private[files] object PlatformWatcher {
   def make(followLinks: Boolean,
            registerable: RegisterableWatchService,
            directoryRegistry: DirectoryRegistry): PathWatcher[PathWatchers.Event] = {
-    val watcher = new NioPathWatcher(directoryRegistry, registerable)
+    val watcher = new NioPathWatcher(directoryRegistry, registerable, followLinks)
     if (followLinks) new SymlinkFollowingPathWatcher(watcher, directoryRegistry) else watcher
   }
   def make(followLinks: Boolean,

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepositories.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepositories.java
@@ -35,7 +35,7 @@ public class FileTreeRepositories {
     final FileCacheDirectoryTree<T> tree =
         new FileCacheDirectoryTree<>(converter, callbackExecutor, symlinkWatcher);
     final PathWatcher<PathWatchers.Event> pathWatcher =
-        PathWatchers.get(false, tree.readOnlyDirectoryRegistry());
+        PathWatchers.get(followLinks, tree.readOnlyDirectoryRegistry());
     pathWatcher.addObserver(
         new Observer<Event>() {
           @Override

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -34,6 +34,7 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
   private final RootDirectories rootDirectories = new RootDirectories();
   private final DirectoryRegistry directoryRegistry;
   private final Converter<WatchedDirectory> converter;
+  private final boolean followLinks;
 
   private CacheObserver<WatchedDirectory> updateCacheObserver(final List<Event> events) {
     return new CacheObserver<WatchedDirectory>() {
@@ -84,8 +85,11 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
   private final NioPathWatcherService service;
 
   NioPathWatcher(
-      final DirectoryRegistry directoryRegistry, final RegisterableWatchService watchService)
+      final DirectoryRegistry directoryRegistry,
+      final RegisterableWatchService watchService,
+      final boolean followLinks)
       throws InterruptedException {
+    this.followLinks = followLinks;
     this.directoryRegistry = directoryRegistry;
     this.service =
         new NioPathWatcherService(
@@ -206,7 +210,7 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
                         @Override
                         public boolean accept(final TypedPath typedPath) {
                           return typedPath.isDirectory()
-                              && !typedPath.isSymbolicLink()
+                              && (followLinks || !typedPath.isSymbolicLink())
                               && directoryRegistry.acceptPrefix(typedPath.getPath());
                         }
                       },

--- a/files/jvm/src/main/java/com/swoval/files/PlatformWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/PlatformWatcher.java
@@ -16,7 +16,7 @@ class PlatformWatcher {
       final DirectoryRegistry directoryRegistry)
       throws InterruptedException, IOException {
     final PathWatcher<Event> pathWatcher =
-        new NioPathWatcher(directoryRegistry, registerableWatchService);
+        new NioPathWatcher(directoryRegistry, registerableWatchService, followLinks);
     return followLinks
         ? new SymlinkFollowingPathWatcher(pathWatcher, directoryRegistry)
         : pathWatcher;

--- a/files/shared/src/test/scala/com/swoval/files/PathWatcherTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/PathWatcherTest.scala
@@ -399,7 +399,7 @@ object NioPathWatcherTest extends PathWatcherTest {
       }
 
   def defaultWatcher(callback: PathWatchers.Event => _): PathWatcher[PathWatchers.Event] = {
-    val res = new NioPathWatcher(new DirectoryRegistryImpl(), RegisterableWatchServices.get())
+    val res = new NioPathWatcher(new DirectoryRegistryImpl(), RegisterableWatchServices.get(), true)
     res.addObserver(callback)
     res
   }


### PR DESCRIPTION
I discovered an issue on linux where when registering a directory that
was a symbolic link, no watch events were detected. This was because the
filter for the CachedDirectoryImpl explicitly excluded symbolic links.
This was problematic because the logic for adding symbolic links only
applied to symbolic links that were found within a registered directory,
not the registered directory itself. With this change, I can likely
change the logic for addSymlink to only apply to files, but I am not
sure how necessary that is at the moment.