### PR TITLE
Bump documentation versions to 2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ swoval
 
 A collection of small developer libraries.
 
-The latest version is `2.0.4`.
+The latest version is `2.0.5`.
 
 File tree views
 =

--- a/files/README.md
+++ b/files/README.md
@@ -20,8 +20,8 @@ Setup
 ==
 The file tree views package is available on
 [maven](https://mvnrepository.com/artifact/com.swoval/file-tree-views) and the latest version is
-`2.0.4`. For sbt builds, it can be added with
-`libraryDependencies += "com.swoval" % "file-tree-views" % "2.0.4"`.
+`2.0.5`. For sbt builds, it can be added with
+`libraryDependencies += "com.swoval" % "file-tree-views" % "2.0.5"`.
 
 FileTreeRepository
 ==
@@ -214,7 +214,7 @@ are javascript native types, i.e. String instead of java.nio.file.Path. The api 
 can be found here: 
 [javascript public api](https://swoval.github.io/files/js/com/swoval/files/node/index.html).
 
-To use, add `"swoval_file_tree_views": "2.0.4"` to your package.json file.
+To use, add `"swoval_file_tree_views": "2.0.5"` to your package.json file.
 
 A simple example:
 ```javascript

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -8,7 +8,7 @@ Usage
 ---
 Add
 ```
-addSbtPlugin("com.swoval" %% "sbt-close-watch" % "2.0.4")
+addSbtPlugin("com.swoval" %% "sbt-close-watch" % "2.0.5")
 ```
 to your project/plugins.sbt. To apply the plugin globally, add those commands to
   `~/.sbt/1.0/plugins/watch.sbt` or `~/.sbt/0.13/plugins/watch.sbt` (creating the file if necessary).

--- a/project/com/swoval/Build.scala
+++ b/project/com/swoval/Build.scala
@@ -35,7 +35,7 @@ import scala.util.{ Properties, Try }
 object Build {
   val scalaCrossVersions @ Seq(scala210, scala211, scala212) = Seq("2.10.7", "2.11.12", "2.12.6")
 
-  def baseVersion: String = "2.0.4-SNAPSHOT"
+  def baseVersion: String = "2.1.0-SNAPSHOT"
 
   def settings(args: Def.Setting[_]*): SettingsDefinition =
     Def.SettingsDefinition.wrapSettingsDefinition(args)


### PR DESCRIPTION
Also set the baseVersion to 2.1.0-SNAPSHOT for development (this will
prevent my having to update it with each patch release).