### PR TITLE
Fix default file tree view semantics

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/CachedDirectoryImpl.scala
+++ b/files/js/src/main/scala/com/swoval/files/CachedDirectoryImpl.scala
@@ -108,7 +108,7 @@ class CachedDirectoryImpl[T <: AnyRef](@BeanProperty val typedPath: TypedPath,
           } else {
             val entry: Entry[T] = leftProjection(findResult).getValue
             val result: List[TypedPath] = new ArrayList[TypedPath]()
-            if (entry != null && filter.accept(entry.getTypedPath))
+            if (entry != null && filter.accept(entry.getTypedPath) && maxDepth == -1)
               result.add(TypedPaths.getDelegate(entry.getTypedPath.getPath, entry.getTypedPath))
             result
           }

--- a/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
@@ -491,6 +491,6 @@ class FileCacheDirectoryTree[T <: AnyRef](private val converter: Converter[T],
                             converter,
                             depth,
                             filter,
-                            FileTreeViews.getDefault(followLinks)).init()
+                            FileTreeViews.getDefault(followLinks, false)).init()
 
 }

--- a/files/js/src/main/scala/com/swoval/files/FileTreeDataViews.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeDataViews.scala
@@ -30,7 +30,7 @@ object FileTreeDataViews {
                             converter,
                             depth,
                             Filters.AllPass,
-                            FileTreeViews.getDefault(followLinks)).init()
+                            FileTreeViews.getDefault(followLinks, false)).init()
 
   /**
    * Container class for [[CachedDirectoryImpl]] entries. Contains both the path to which the
@@ -64,12 +64,12 @@ object FileTreeDataViews {
   trait Converter[R] {
 
     /**
-     * Convert the path to a value.
+     * Convert the typedPath to a value.
      *
-     * @param path the path to convert
+     * @param typedPath the typedPath to convert
      * @return the converted value
      */
-    def apply(path: TypedPath): R
+    def apply(typedPath: TypedPath): R
 
   }
 

--- a/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
@@ -52,7 +52,7 @@ object FileTreeViews {
                             PATH_CONVERTER,
                             depth,
                             Filters.AllPass,
-                            getDefault(followLinks)).init()
+                            getDefault(followLinks, false)).init()
 
   /**
    * Returns an instance of [[FileTreeView]] that uses only apis available in java.nio.file.
@@ -86,7 +86,22 @@ object FileTreeViews {
    * @return an instance of [[FileTreeView]].
    */
   def getDefault(followLinks: Boolean): FileTreeView =
-    new SimpleFileTreeView(defaultDirectoryLister, followLinks)
+    getDefault(followLinks, true)
+
+  /**
+   * Returns the default [[FileTreeView]] for the runtime platform. If a native implementation
+   * is present, it will be used. Otherwise, it will fall back to the java.nio.file based
+   * implementation.
+   *
+   * @param followLinks toggles whether or not to follow the targets of symbolic links to
+   *     directories.
+   * @param ignoreExceptions toggles whether or not to ignore IOExceptions thrown while listing the
+   *     directory. If true, some files that are found may be silently dropped if accessing them
+   *     caused an exception.
+   * @return an instance of [[FileTreeView]].
+   */
+  def getDefault(followLinks: Boolean, ignoreExceptions: Boolean): FileTreeView =
+    new SimpleFileTreeView(defaultDirectoryLister, followLinks, ignoreExceptions)
 
   /**
    * List the contents of a path.
@@ -96,7 +111,7 @@ object FileTreeViews {
    *     path itself is returned. Otherwise an empty list is returned.
    * @param maxDepth the maximum depth of children to include in the results
    * @param filter only include paths accepted by this filter
-   * @return a [[java.util.List]] of [[TypedPath]]
+   * @return a [[java.util.List]] of [[com.swoval.files.TypedPath]]
    */
   def list(path: Path, maxDepth: Int, filter: Filter[_ >: TypedPath]): List[TypedPath] =
     defaultFileTreeView.list(path, maxDepth, filter)

--- a/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/NioPathWatcher.scala
@@ -195,7 +195,7 @@ class NioPathWatcher(private val directoryRegistry: DirectoryRegistry,
               typedPath.isDirectory && !typedPath.isSymbolicLink && directoryRegistry
                 .acceptPrefix(typedPath.getPath)
           },
-          FileTreeViews.getDefault(false)
+          FileTreeViews.getDefault(false, false)
         ).init()
         init = true
         rootDirectories.put(toAdd, result)

--- a/files/jvm/src/main/java/com/swoval/files/CachedDirectoryImpl.java
+++ b/files/jvm/src/main/java/com/swoval/files/CachedDirectoryImpl.java
@@ -126,7 +126,7 @@ class CachedDirectoryImpl<T> implements CachedDirectory<T> {
           } else {
             final Entry<T> entry = leftProjection(findResult).getValue();
             final List<TypedPath> result = new ArrayList<>();
-            if (entry != null && filter.accept(entry.getTypedPath()))
+            if (entry != null && filter.accept(entry.getTypedPath()) && maxDepth == -1)
               result.add(
                   TypedPaths.getDelegate(entry.getTypedPath().getPath(), entry.getTypedPath()));
             return result;

--- a/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
@@ -550,7 +550,11 @@ class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<
   private CachedDirectory<T> newCachedDirectory(final Path path, final int depth)
       throws IOException {
     return new CachedDirectoryImpl<>(
-            TypedPaths.get(path), converter, depth, filter, FileTreeViews.getDefault(followLinks))
+            TypedPaths.get(path),
+            converter,
+            depth,
+            filter,
+            FileTreeViews.getDefault(followLinks, false))
         .init();
   }
 }

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeDataViews.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeDataViews.java
@@ -33,7 +33,7 @@ public class FileTreeDataViews {
             converter,
             depth,
             Filters.AllPass,
-            FileTreeViews.getDefault(followLinks))
+            FileTreeViews.getDefault(followLinks, false))
         .init();
   }
 

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
@@ -56,7 +56,11 @@ public class FileTreeViews {
   public static DirectoryView cached(final Path path, final int depth, final boolean followLinks)
       throws IOException {
     return new CachedDirectoryImpl<>(
-            TypedPaths.get(path), PATH_CONVERTER, depth, Filters.AllPass, getDefault(followLinks))
+            TypedPaths.get(path),
+            PATH_CONVERTER,
+            depth,
+            Filters.AllPass,
+            getDefault(followLinks, false))
         .init();
   }
 
@@ -98,7 +102,23 @@ public class FileTreeViews {
    * @return an instance of {@link FileTreeView}.
    */
   public static FileTreeView getDefault(final boolean followLinks) {
-    return new SimpleFileTreeView(defaultDirectoryLister, followLinks);
+    return getDefault(followLinks, true);
+  }
+
+  /**
+   * Returns the default {@link FileTreeView} for the runtime platform. If a native implementation
+   * is present, it will be used. Otherwise, it will fall back to the java.nio.file based
+   * implementation.
+   *
+   * @param followLinks toggles whether or not to follow the targets of symbolic links to
+   *     directories.
+   * @param ignoreExceptions toggles whether or not to ignore IOExceptions thrown while listing the
+   *     directory. If true, some files that are found may be silently dropped if accessing them
+   *     caused an exception.
+   * @return an instance of {@link FileTreeView}.
+   */
+  public static FileTreeView getDefault(final boolean followLinks, final boolean ignoreExceptions) {
+    return new SimpleFileTreeView(defaultDirectoryLister, followLinks, ignoreExceptions);
   }
 
   /**
@@ -109,7 +129,7 @@ public class FileTreeViews {
    *     path itself is returned. Otherwise an empty list is returned.
    * @param maxDepth the maximum depth of children to include in the results
    * @param filter only include paths accepted by this filter
-   * @return a {@link java.util.List} of {@link TypedPath}
+   * @return a {@link java.util.List} of {@link com.swoval.files.TypedPath}
    * @throws IOException if the Path doesn't exist
    */
   public static List<TypedPath> list(

--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -214,7 +214,7 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
                               && directoryRegistry.acceptPrefix(typedPath.getPath());
                         }
                       },
-                      FileTreeViews.getDefault(false))
+                      FileTreeViews.getDefault(false, false))
                   .init();
           init = true;
           rootDirectories.put(toAdd, result);

--- a/files/jvm/src/test/scala/com/swoval/files/QuickListReflectionTest.scala
+++ b/files/jvm/src/test/scala/com/swoval/files/QuickListReflectionTest.scala
@@ -2,7 +2,7 @@ package com.swoval.files
 
 object QuickListReflectionTest {
   def main(args: Array[String]): Unit = {
-    val default = FileTreeViews.getDefault(false)
+    val default = FileTreeViews.getDefault(false, false)
     val simpleFileTreeView = classOf[SimpleFileTreeView]
     val field = simpleFileTreeView.getDeclaredField("directoryLister")
     field.setAccessible(true)


### PR DESCRIPTION
This commit makes the default file tree view have the same semantics as
the default cached file tree view. Prior to this, there were two issues:

1) When the depth was specified as -1, it was effectively treated as 0.
   This made it impossible to get the TypedPath for a specific file
   through the file tree view.
2) Don't throw automatically re-throw exceptions that are encountered
   when filling the results. It may be expected that, say, an
   AccessDeniedException is thrown when recursively listing a directory.
   In most cases, we'd want to simply ignore the privileged file and
   continue filling the results. This is now configurable via a flag in
   FileTreeViews.getDefault. I did change the default to ignore
   exceptions. I figure it doesn't really matter because the only
   downstream consumer is sbt and no version has been released using
   this api.

Also, there was an issue where in the cached directory case, calling
`view.list(path, 0, AllPass)` would return the path itself it were
actually a file. This was not intentional, so I fixed that.