### PR TITLE
Fix off by one error with registration order

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileCacheDirectoryTree.scala
@@ -371,7 +371,7 @@ class FileCacheDirectoryTree[T <: AnyRef](private val converter: Converter[T],
         if (maxDepth == java.lang.Integer.MAX_VALUE) {
           toRemove.add(dir.getPath)
         } else {
-          val depth: Int = path.relativize(dir.getPath).getNameCount - 1
+          val depth: Int = path.relativize(dir.getPath).getNameCount
           if (maxDepth - depth >= dir.getMaxDepth) {
             toRemove.add(dir.getPath)
           }

--- a/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
@@ -409,7 +409,7 @@ class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<
         if (maxDepth == Integer.MAX_VALUE) {
           toRemove.add(dir.getPath());
         } else {
-          int depth = path.relativize(dir.getPath()).getNameCount() - 1;
+          int depth = path.relativize(dir.getPath()).getNameCount();
           if (maxDepth - depth >= dir.getMaxDepth()) {
             toRemove.add(dir.getPath());
           }


### PR DESCRIPTION
I found an obscure bug in sbt where when using a FileTreeRepository, it
was possible for events to be dropped. Suppose that you have base
directory foo and subdirectoyr foo/bar. Now suppose that we first
register foo/bar with depth 0 and then register foo with depth zero. The
cleanupDirectories callback would actually remove the registration for
foo/bar even though foo was not registered with depth 1, which would be
necessary for it to actually cover foo/bar if foo/bar had been
registered with depth zero.

Off by one errors are never fun, but at least I added a regression test