### PR TITLE
Add support for relative paths

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/ApplePathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/ApplePathWatcher.scala
@@ -129,8 +129,11 @@ class ApplePathWatcher(private val latency: java.lang.Long,
    *     first time the directory is registered or when the depth is changed. Otherwise it should
    *     return false.
    */
-  override def register(path: Path, maxDepth: Int): Either[IOException, Boolean] =
-    register(path, flags, maxDepth)
+  override def register(path: Path, maxDepth: Int): Either[IOException, Boolean] = {
+    val absolutePath: Path =
+      if (path.isAbsolute) path else path.toAbsolutePath()
+    register(absolutePath, flags, maxDepth)
+  }
 
   /**
    * Registers with additional flags
@@ -193,9 +196,11 @@ class ApplePathWatcher(private val latency: java.lang.Long,
    * @param path The directory to remove from monitoring
    */
   override def unregister(path: Path): Unit = {
+    val absolutePath: Path =
+      if (path.isAbsolute) path else path.toAbsolutePath()
     if (!closed.get) {
-      directoryRegistry.removeDirectory(path)
-      val stream: Stream = appleFileEventStreams.remove(path)
+      directoryRegistry.removeDirectory(absolutePath)
+      val stream: Stream = appleFileEventStreams.remove(absolutePath)
       if (stream != null && stream.handle != Handles.INVALID) {
         try stream.close()
         catch {

--- a/files/js/src/main/scala/com/swoval/files/DirectoryRegistry.scala
+++ b/files/js/src/main/scala/com/swoval/files/DirectoryRegistry.scala
@@ -12,16 +12,55 @@ import java.util.Map
 import java.util.concurrent.ConcurrentHashMap
 import DirectoryRegistryImpl._
 
+/**
+ * Tracks which directories the user wishes to monitor. This can be used to determine whether or not
+ * a path is part of the subtree specified by the set of paths registered by the user.
+ */
 trait DirectoryRegistry extends Filter[Path] with AutoCloseable {
 
+  /**
+   * Add the input directory to the list of registered directories.
+   *
+   * @param path the directory to register
+   * @param maxDepth controls how many levels of the children of the path should be monitored
+   * @return true if the directory has not been previously registered before or if the new maxDepth
+   *     value is greater than the previous value.
+   */
   def addDirectory(path: Path, maxDepth: Int): Boolean
 
+  /**
+   * The maximum depth of children of the path to accept.
+   *
+   * @param path the registered path
+   * @return the maximum depth of children if the path has been registered. Otherwise it returns
+   *     Integer.MIN_VALUE.
+   */
   def maxDepthFor(path: Path): Int
 
+  /**
+   * Returns a map of Path -> maxDepth for each path.
+   *
+   * @return a map of Path -> maxDepth for each path.
+   */
   def registered(): Map[Path, Integer]
 
+  /**
+   * Remove the path from monitoring.
+   *
+   * @param path the path to stop monitoring.
+   */
   def removeDirectory(path: Path): Unit
 
+  /**
+   * Returns true if this path is a prefix of a registered path. The intended use case is for the
+   * [[NioPathWatcher]] which always has the root directory as the base. This is so that we can
+   * ensure that if we register a directory that does not yet exist, that we will detect when the
+   * directory is created. For example, if we want to monitor '/foo/bar/baz', then we would accept
+   * '/foo/bar' as a valid prefix path, but we would not accept '/foo/buzz' as a valid prefix path.
+   *
+   * @param path the path to compare against the registered path
+   * @return true if the path is a prefix of a registered path.
+   */
   def acceptPrefix(path: Path): Boolean
 
   override def close(): Unit

--- a/files/js/src/main/scala/com/swoval/files/FileTreeRepositoryImpl.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeRepositoryImpl.scala
@@ -80,14 +80,19 @@ class FileTreeRepositoryImpl[T <: AnyRef](private val directoryTree: FileCacheDi
     directoryTree.listEntries(path, maxDepth, filter)
 
   override def register(path: Path, maxDepth: Int): Either[IOException, Boolean] =
-    try Either.right(watcher.register(path, maxDepth))
-    catch {
+    try {
+      val absolutePath: Path =
+        if (path.isAbsolute) path else path.toAbsolutePath()
+      Either.right(watcher.register(absolutePath, maxDepth))
+    } catch {
       case e: IOException => Either.left(e)
 
     }
 
   override def unregister(path: Path): Unit = {
-    watcher.unregister(path)
+    val absolutePath: Path =
+      if (path.isAbsolute) path else path.toAbsolutePath()
+    watcher.unregister(absolutePath)
   }
 
   override def list(path: Path, maxDepth: Int, filter: Filter[_ >: TypedPath]): List[TypedPath] =

--- a/files/js/src/main/scala/com/swoval/files/PollingPathWatcher.scala
+++ b/files/js/src/main/scala/com/swoval/files/PollingPathWatcher.scala
@@ -56,18 +56,22 @@ class PollingPathWatcher(private val converter: Converter[java.lang.Long],
     )
 
   override def register(path: Path, maxDepth: Int): Either[IOException, Boolean] = {
+    val absolutePath: Path =
+      if (path.isAbsolute) path else path.toAbsolutePath()
     var result: Boolean = false
     val entries: List[FileTreeDataViews.Entry[java.lang.Long]] =
-      getEntries(path, maxDepth)
+      getEntries(absolutePath, maxDepth)
     this.synchronized {
       addAll(oldEntries, entries)
-      result = registry.addDirectory(path, maxDepth)
+      result = registry.addDirectory(absolutePath, maxDepth)
     }
     Either.right(result)
   }
 
   override def unregister(path: Path): Unit = {
-    registry.removeDirectory(path)
+    val absolutePath: Path =
+      if (path.isAbsolute) path else path.toAbsolutePath()
+    registry.removeDirectory(absolutePath)
   }
 
   override def close(): Unit = {

--- a/files/js/src/main/scala/com/swoval/files/TypedPaths.scala
+++ b/files/js/src/main/scala/com/swoval/files/TypedPaths.scala
@@ -64,14 +64,15 @@ object TypedPaths {
 
     }
 
-  def get(path: Path, kind: Int): TypedPath = new TypedPathImpl(path) {
-    override def exists(): Boolean = (kind & Entries.NONEXISTENT) == 0
+  def get(path: Path, kind: Int): TypedPath =
+    new TypedPathImpl(if (path.isAbsolute) path else path.toAbsolutePath()) {
+      override def exists(): Boolean = (kind & Entries.NONEXISTENT) == 0
 
-    override def isDirectory(): Boolean = (kind & Entries.DIRECTORY) != 0
+      override def isDirectory(): Boolean = (kind & Entries.DIRECTORY) != 0
 
-    override def isFile(): Boolean = (kind & Entries.FILE) != 0
+      override def isFile(): Boolean = (kind & Entries.FILE) != 0
 
-    override def isSymbolicLink(): Boolean = (kind & Entries.LINK) != 0
-  }
+      override def isSymbolicLink(): Boolean = (kind & Entries.LINK) != 0
+    }
 
 }

--- a/files/js/src/main/scala/com/swoval/files/node/PublicApi.scala
+++ b/files/js/src/main/scala/com/swoval/files/node/PublicApi.scala
@@ -218,15 +218,6 @@ class FileTreeRepository[T <: AnyRef] protected[node] (
    * @param path the path to unregister
    */
   def unregister(path: String): Unit = underlying.unregister(Paths.get(path))
-  /**
- * List all of the files for the {@code path}, returning only those files that are accepted by the
- * provided filter.
- *
- * @param path the root path to list
- * @param maxDepth the maximum depth of subdirectories to query
- * @param filter include only paths accepted by the filter
- * @return a List of [[java.nio.file.Path]] instances accepted by the filter.
- */
 }
 
 @JSExportTopLevel("PathWatchers")

--- a/files/jvm/src/main/java/com/swoval/files/ApplePathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/ApplePathWatcher.java
@@ -81,7 +81,8 @@ class ApplePathWatcher implements PathWatcher<PathWatchers.Event> {
    */
   @Override
   public Either<IOException, Boolean> register(final Path path, final int maxDepth) {
-    return register(path, flags, maxDepth);
+    final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
+    return register(absolutePath, flags, maxDepth);
   }
 
   /**
@@ -147,9 +148,10 @@ class ApplePathWatcher implements PathWatcher<PathWatchers.Event> {
   @Override
   @SuppressWarnings("EmptyCatchBlock")
   public void unregister(final Path path) {
+    final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
     if (!closed.get()) {
-      directoryRegistry.removeDirectory(path);
-      final Stream stream = appleFileEventStreams.remove(path);
+      directoryRegistry.removeDirectory(absolutePath);
+      final Stream stream = appleFileEventStreams.remove(absolutePath);
       if (stream != null && stream.handle != Handles.INVALID) {
         try {
           stream.close();

--- a/files/jvm/src/main/java/com/swoval/files/DirectoryRegistry.java
+++ b/files/jvm/src/main/java/com/swoval/files/DirectoryRegistry.java
@@ -10,15 +10,55 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Tracks which directories the user wishes to monitor. This can be used to determine whether or not
+ * a path is part of the subtree specified by the set of paths registered by the user.
+ */
 interface DirectoryRegistry extends Filter<Path>, AutoCloseable {
+
+  /**
+   * Add the input directory to the list of registered directories.
+   *
+   * @param path the directory to register
+   * @param maxDepth controls how many levels of the children of the path should be monitored
+   * @return true if the directory has not been previously registered before or if the new maxDepth
+   *     value is greater than the previous value.
+   */
   boolean addDirectory(final Path path, final int maxDepth);
 
+  /**
+   * The maximum depth of children of the path to accept.
+   *
+   * @param path the registered path
+   * @return the maximum depth of children if the path has been registered. Otherwise it returns
+   *     Integer.MIN_VALUE.
+   */
   int maxDepthFor(final Path path);
 
+  /**
+   * Returns a map of Path -> maxDepth for each path.
+   *
+   * @return a map of Path -> maxDepth for each path.
+   */
   Map<Path, Integer> registered();
 
+  /**
+   * Remove the path from monitoring.
+   *
+   * @param path the path to stop monitoring.
+   */
   void removeDirectory(final Path path);
 
+  /**
+   * Returns true if this path is a prefix of a registered path. The intended use case is for the
+   * {@link NioPathWatcher} which always has the root directory as the base. This is so that we can
+   * ensure that if we register a directory that does not yet exist, that we will detect when the
+   * directory is created. For example, if we want to monitor '/foo/bar/baz', then we would accept
+   * '/foo/bar' as a valid prefix path, but we would not accept '/foo/buzz' as a valid prefix path.
+   *
+   * @param path the path to compare against the registered path
+   * @return true if the path is a prefix of a registered path.
+   */
   boolean acceptPrefix(final Path path);
 
   @Override

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
@@ -84,7 +84,8 @@ class FileTreeRepositoryImpl<T> implements FileTreeRepository<T> {
   @Override
   public Either<IOException, Boolean> register(final Path path, final int maxDepth) {
     try {
-      return Either.right(watcher.register(path, maxDepth));
+      final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
+      return Either.right(watcher.register(absolutePath, maxDepth));
     } catch (final IOException e) {
       return Either.left(e);
     }
@@ -93,7 +94,8 @@ class FileTreeRepositoryImpl<T> implements FileTreeRepository<T> {
   @Override
   @SuppressWarnings("EmptyCatchBlock")
   public void unregister(final Path path) {
-    watcher.unregister(path);
+    final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
+    watcher.unregister(absolutePath);
   }
 
   @Override

--- a/files/jvm/src/main/java/com/swoval/files/PollingPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/PollingPathWatcher.java
@@ -63,18 +63,20 @@ class PollingPathWatcher implements PathWatcher<PathWatchers.Event> {
 
   @Override
   public Either<IOException, Boolean> register(final Path path, final int maxDepth) {
+    final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
     boolean result;
-    final List<FileTreeDataViews.Entry<Long>> entries = getEntries(path, maxDepth);
+    final List<FileTreeDataViews.Entry<Long>> entries = getEntries(absolutePath, maxDepth);
     synchronized (this) {
       addAll(oldEntries, entries);
-      result = registry.addDirectory(path, maxDepth);
+      result = registry.addDirectory(absolutePath, maxDepth);
     }
     return Either.right(result);
   }
 
   @Override
   public void unregister(final Path path) {
-    registry.removeDirectory(path);
+    final Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
+    registry.removeDirectory(absolutePath);
   }
 
   @Override

--- a/files/jvm/src/main/java/com/swoval/files/TypedPaths.java
+++ b/files/jvm/src/main/java/com/swoval/files/TypedPaths.java
@@ -91,7 +91,7 @@ public class TypedPaths {
   }
 
   static TypedPath get(final Path path, final int kind) {
-    return new TypedPathImpl(path) {
+    return new TypedPathImpl(path.isAbsolute() ? path : path.toAbsolutePath()) {
       @Override
       public boolean exists() {
         return (kind & Entries.NONEXISTENT) == 0;

--- a/files/shared/src/test/scala/com/swoval/files/ApplePathWatcherTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/ApplePathWatcherTest.scala
@@ -1,17 +1,20 @@
 package com.swoval.files
 
-import java.nio.file.Paths
-import java.util.concurrent.TimeUnit
+import java.io.IOException
+import java.nio.file.{ Path, Paths }
+import java.util.concurrent.{ ConcurrentHashMap, TimeUnit }
 
+import com.swoval.files.FileTreeViews.Observer
 import com.swoval.files.PathWatchers.Event
 import com.swoval.files.TestHelpers._
 import com.swoval.files.apple.Flags
 import com.swoval.files.test._
+import com.swoval.functional
 import com.swoval.test._
 import utest._
 
 import scala.concurrent.duration._
-
+import scala.collection.JavaConverters._
 object ApplePathWatcherTest extends TestSuite {
   val DEFAULT_LATENCY = 5.milliseconds
   val dirFlags = new Flags.Create().setNoDefer()

--- a/files/shared/src/test/scala/com/swoval/files/BasicFileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/BasicFileCacheTest.scala
@@ -281,6 +281,19 @@ trait BasicFileCacheTest extends TestSuite with FileCacheTest {
           }
         }
       }
+      'relative - withTempDirectory(targetDir) { dir =>
+        val latch = new CountDownLatch(1)
+        val file = dir.resolve("file")
+        val callback = (e: Entry[Path]) =>
+          if (e.getTypedPath.getPath.getFileName.toString == "file") latch.countDown()
+        usingAsync(simpleCache(callback)) { w =>
+          w.register(baseDir.relativize(dir))
+          Files.createFile(file)
+          latch.waitFor(DEFAULT_TIMEOUT) {
+            assert(Files.exists(file))
+          }
+        }
+      }
       'order - withTempDirectory { dir =>
         withTempDirectory(dir) { subdir =>
           val latch = new CountDownLatch(1)

--- a/files/shared/src/test/scala/com/swoval/files/package.scala
+++ b/files/shared/src/test/scala/com/swoval/files/package.scala
@@ -2,12 +2,13 @@ package com.swoval
 package files
 
 import java.io.{ File, FileFilter, IOException }
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 
 import com.swoval.files.FileTreeDataViews.{ CacheObserver, Converter, Entry }
 import com.swoval.files.FileTreeViews.Observer
 import com.swoval.files.test.platform.Bool
 import com.swoval.functional.{ Consumer, Filter }
+import com.swoval.runtime.Platform
 import com.swoval.test._
 import utest._
 
@@ -19,6 +20,14 @@ import utest._
  *
  */
 object TestHelpers extends PlatformFiles {
+
+  val baseDir: Path = Paths.get("").toAbsolutePath
+  val targetDir: Path = baseDir.getFileName.toString match {
+    case "js" | "jvm" => baseDir.resolve("target")
+    case _ =>
+      baseDir.resolve("files").resolve(if (Platform.isJVM) "jvm" else "js").resolve("target")
+  }
+
   val Ignore: CacheObserver[_] = getObserver[Path]((_: Entry[Path]) => {})
 
   def getObserver[T <: AnyRef](


### PR DESCRIPTION
It was reported by @scf37 that relative paths do not work for monitor
registration. In this commit, I change every implementation of
PathWatcher.register and PathWatcher.unregister to convert the input
path to an absolute path, if necessary. I also add a basic test that
relative work for both a PathWatcher and a FileTreeRepository.