### PR TITLE
Rename the swoval.debug property

### DIFF
--- a/files/jvm/src/test/scala/com/swoval/files/AllTests.scala
+++ b/files/jvm/src/test/scala/com/swoval/files/AllTests.scala
@@ -25,7 +25,7 @@ object AllTests {
     def printContent(outputStream: OutputStream): Unit = println(builder.toString)
   }
   def baseArgs(count: String, timeout: String, debug: Option[String]): Int = {
-    debug.foreach(System.setProperty("swoval.debug", _))
+    debug.foreach(System.setProperty("swoval.test.debug", _))
     count.intValue(default = 1)
   }
   def main(args: Array[String]): Unit = {

--- a/files/shared/src/test/scala/com/swoval/files/test/package.scala
+++ b/files/shared/src/test/scala/com/swoval/files/test/package.scala
@@ -30,7 +30,7 @@ package object test {
     val res = com.swoval.test
       .usingT(closeable)(f)
     res.onComplete {
-      case Success(_) => if ("true" == System.getProperty("swoval.debug")) printLog(testLogger)
+      case Success(_) => if ("true" == System.getProperty("swoval.test.debug")) printLog(testLogger)
       case Failure(_) => printLog(testLogger)
     }(utest.framework.ExecutionContext.RunNow)
     res
@@ -39,7 +39,7 @@ package object test {
       implicit testLogger: TestLogger): Future[R] = {
     val res = com.swoval.test.usingAsyncT(closeable)(f)
     res.onComplete {
-      case Success(_)            => if ("true" == System.getProperty("swoval.debug")) printLog(testLogger)
+      case Success(_)            => if ("true" == System.getProperty("swoval.test.debug")) printLog(testLogger)
       case Failure(_: Throwable) => printLog(testLogger)
     }(utest.framework.ExecutionContext.RunNow)
     res

--- a/project/com/swoval/Build.scala
+++ b/project/com/swoval/Build.scala
@@ -567,9 +567,9 @@ object Build {
       forkOptions in Test := {
         val prev = (forkOptions in Test).value
         prev.withRunJVMOptions(
-          prev.runJVMOptions ++ Option(System.getProperty("swoval.debug")).map(v =>
-            s"-Dswoval.debug=$v") ++ Option(System.getProperty("swoval.debug.logger")).map(v =>
-            s"-Dswoval.debug.logger=$v"))
+          prev.runJVMOptions ++ Option(System.getProperty("swoval.test.debug")).map(v =>
+            s"-Dswoval.test.debug=$v") ++ Option(System.getProperty("swoval.test.debug.logger")).map(v =>
+            s"-Dswoval.test.debug.logger=$v"))
       },
       travisQuickListReflectionTest := {
         quickListReflectionTest
@@ -596,7 +596,7 @@ object Build {
           "com.swoval.files.AllTests",
           count.toString,
           System.getProperty("swoval.alltest.timeout", "20"),
-          System.getProperty("swoval.debug", "false"),
+          System.getProperty("swoval.test.debug", "false"),
         )
         val process = pb.inheritIO().start()
         process.waitFor()


### PR DESCRIPTION
I got confused and thought this controlled the actual debug logger.