### PR TITLE
Clarify missing file test case

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ for:
     - curl -sL https://github.com/sbt/sbt/releases/download/v1.4.4/sbt-1.4.4.tgz > ~/sbt-bin.tgz
     - mkdir ~/sbt
     - tar -xf ~/sbt-bin.tgz --directory ~/sbt
-    - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.0/install.sh | bash && . ~/.jabba/jabba.sh
+    - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
     - jabba install adopt@1.8.0-272
     - jabba use adopt@1.8.0-272
     - export PATH="~/sbt/sbt/bin:$PATH"
@@ -51,7 +51,7 @@ for:
     - curl -sL https://github.com/sbt/sbt/releases/download/v1.4.4/sbt-1.4.4.tgz > ~/sbt-bin.tgz
     - mkdir ~/sbt
     - tar -xf ~/sbt-bin.tgz --directory ~/sbt
-    - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.0/install.sh | bash && . ~/.jabba/jabba.sh
+    - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
     - jabba install adopt@1.8.0-272
     - jabba use adopt@1.8.0-272
     - export PATH="~/sbt/sbt/bin:$PATH"


### PR DESCRIPTION
In #146, it was reported that missing files were not correctly tracked
by the file cache. This was a bit of a misunderstanding because when a
file is registered with the file cache, its parent is not automatically
registered. The parent is monitored for watch events if the file doesn't
exist so that we can detect if the file is created but listing the
parent directory will not work. The file has to be directly queried.