### PR TITLE
Update register results and log warnings

### DIFF
--- a/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
@@ -420,6 +420,7 @@ class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<
           if (Loggers.shouldLog(logger, Level.WARN)) {
             logger.warn(this + " failed to register " + absolutePath + " for monitoring");
           }
+          throw Either.leftProjection(res).getValue();
         }
         final List<CachedDirectory<T>> dirs = new ArrayList<>(directories.values());
         Collections.sort(

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepositoryImpl.java
@@ -101,6 +101,11 @@ class FileTreeRepositoryImpl<T> implements FileTreeRepository<T> {
           Either.right(watcher.register(absolutePath, maxDepth));
       if (Loggers.shouldLog(logger, Level.DEBUG))
         logger.debug(this + " registered " + path + " with max depth " + maxDepth);
+      if (res.isLeft()) {
+        if (Loggers.shouldLog(logger, Level.WARN)) {
+          logger.warn(this + " failed to register " + path + " for monitoring");
+        }
+      }
       return res;
     } catch (final IOException e) {
       return Either.left(e);

--- a/files/jvm/src/main/java/com/swoval/files/apple/CreateStreamException.java
+++ b/files/jvm/src/main/java/com/swoval/files/apple/CreateStreamException.java
@@ -1,0 +1,10 @@
+package com.swoval.files.apple;
+
+import java.io.IOException;
+
+/** Exception that is thrown when the system is unable to create a file event stream. */
+public class CreateStreamException extends IOException {
+  public CreateStreamException(final String path) {
+    super(path);
+  }
+}

--- a/files/shared/src/test/scala/com/swoval/files/ApplePathWatcherTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/ApplePathWatcherTest.scala
@@ -84,6 +84,13 @@ object ApplePathWatcherTest extends TestSuite {
           }
         }
       }
+      "register results" - withTempDirectory { dir =>
+        implicit val logger: TestLogger = new CachingLogger
+        using(defaultWatcher((_: Event) => ())) { w =>
+          assert(w.register(dir).get)
+          assert(!w.register(dir).get)
+        }
+      }
     }
   }
 }

--- a/project/com/swoval/Build.scala
+++ b/project/com/swoval/Build.scala
@@ -514,7 +514,7 @@ object Build {
             instruction = 82,
             branch = 73,
             line = 84,
-            clazz = 100,
+            clazz = 99,
             complexity = 68,
             method = 84
           )


### PR DESCRIPTION
On osx, there can be situations in which the OS fails to register a
watch stream which can break functionality. When this happens, we want
to return an error to the caller and log a warning since this is very
likely to break the application. There is an argument that we should
actually bomb out on an error rather than just log a warning, but that
seems a bit aggressive.