### PR TITLE
Do not dealias symlinks in watch registration

### DIFF
--- a/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
+++ b/files/jvm/src/main/java/com/swoval/files/NioPathWatcher.java
@@ -182,16 +182,10 @@ class NioPathWatcher implements PathWatcher<PathWatchers.Event>, AutoCloseable {
     final int existingMaxDepth = directoryRegistry.maxDepthFor(absolutePath);
     boolean result = existingMaxDepth < maxDepth;
     final TypedPath typedPath = TypedPaths.get(absolutePath);
-    Path realPath;
-    try {
-      realPath = absolutePath.toRealPath();
-    } catch (final IOException e) {
-      realPath = absolutePath.toAbsolutePath();
-    }
     if (result) {
-      directoryRegistry.addDirectory(typedPath.getPath(), maxDepth);
+      directoryRegistry.addDirectory(absolutePath, maxDepth);
     }
-    final CachedDirectory<WatchedDirectory> dir = getOrAdd(realPath);
+    final CachedDirectory<WatchedDirectory> dir = getOrAdd(absolutePath);
     final List<Event> events = new ArrayList<>();
     if (dir != null) {
       final List<FileTreeDataViews.Entry<WatchedDirectory>> directories =


### PR DESCRIPTION
An sbt user reported that when they symlinked the ~/.sbt directory that
sbt would error on every other reload attempt. I tracked this down to
registering the aliased directory with the NioPathWatcher. For reasons
that I cannot remember, we were dealiasing symlinks in the
NioPathWatcher registration method which was the cause of this issue.
All of the tests pass without the dealiasing so I am going to assume
that it is safe to stop dealiasing and hopefully that assumption holds
up. The analogous register method in ApplePathWatcher did not dealias
symlinks so this issue only should have appeared on windows or linux.

After applying this change, I was able to successfully reload a test
project with a symlinked ~/.sbt directory without issues.