### PR TITLE
Fix bug with watching individual files

### DIFF
--- a/files/shared/src/test/scala/com/swoval/files/PathWatcherTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/PathWatcherTest.scala
@@ -309,6 +309,24 @@ trait PathWatcherTest extends TestSuite {
                    )
                  })
     }
+    "empty subs" - withTempDirectory { dir =>
+      implicit val logger: TestLogger = new CachingLogger
+      withTempDirectory(dir) { subdir =>
+        val emptySubdir = dir.resolve("empty")
+        val file = subdir.resolve("foo")
+        val latch = new CountDownLatch(1)
+        val callback =
+          (e: PathWatchers.Event) => if (e.path == file) { latch.countDown() }
+        usingAsync(defaultWatcher(callback)) { w =>
+          w.register(emptySubdir, 0)
+          w.register(file, 0)
+          file.createFile()
+          latch.waitFor(DEFAULT_TIMEOUT) {
+            assert(file.exists())
+          }
+        }
+      }
+    }
     'depth - {
       'limit - withTempDirectory { dir =>
         implicit val logger: TestLogger = new CachingLogger

--- a/project/com/swoval/Build.scala
+++ b/project/com/swoval/Build.scala
@@ -515,7 +515,7 @@ object Build {
             branch = 73,
             line = 84,
             clazz = 99,
-            complexity = 68,
+            complexity = 66,
             method = 84
           )
         ),


### PR DESCRIPTION
This was a subtle bug first reported as
https://github.com/swoval/swoval/issues/152 in the context of
https://github.com/scalameta/metals/issues/3379. I had been aware of
this issue but hadn't a repro to help track it down before the above
ticket was filed.

For posterity, the way that this works is that swoval has a
datastructure CachedDirectory that maintains an in memory view of a
directory on the file system (hence the name file tree views). Each
entry in the cache, which could represent a directory or a regular file,
can have a value associated with it. Typically this might be something
like the file attributes but in the case of the NioPathWatcher, we
actually store the watch key in the tree.

The subtle issue that this issue triggered was in the scenario:
```
a (dir):
  b (non existent dir):
  c (existent dir):
    d (non-existent file)
```

If a user of the library created a watch on a/b and then created a watch
on a/c/d, then the creation of a/c/d would not be detected. This was because the
watch on a/b transitively creates a watch on a. When a/c/d is created, c
exists but is ignored because the CachedDirectory has a filter that only
accepts directories that could be watched. Because a/c has not been
registered yet, no watch is created. When the watch on a/c/d is added, we
find that the root entry for a. The bug was that the code only updated
the tree for a/c/d but not a/c. As a result no watch was created on a/c
even though a watch on a/c is needed to detect the creation of a/c/d.

This commit fixes the issue by finding the longest prefix of the
registered file in the directory and updating that file within the
cached directory tree to ensure that any watches that may have
previously been ignored are created.