### PR TITLE
Add support for filtering paths in FileTreeRepository

### DIFF
--- a/files/jvm/src/main/java/com/swoval/files/DirectoryRegistry.java
+++ b/files/jvm/src/main/java/com/swoval/files/DirectoryRegistry.java
@@ -68,6 +68,17 @@ interface DirectoryRegistry extends Filter<Path>, AutoCloseable {
 class DirectoryRegistries {
   private DirectoryRegistries() {}
 
+  static Filter<TypedPath> toTypedPathFilter(
+      final DirectoryRegistry registry, final Filter<TypedPath> filter) {
+    if (filter == null) return toTypedPathFilter(registry);
+    return new Filter<TypedPath>() {
+      @Override
+      public boolean accept(final TypedPath typedPath) {
+        return filter.accept(typedPath) && registry.accept(typedPath.getPath());
+      }
+    };
+  }
+
   static Filter<TypedPath> toTypedPathFilter(final DirectoryRegistry registry) {
     return new Filter<TypedPath>() {
       @Override

--- a/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileCacheDirectoryTree.java
@@ -101,7 +101,7 @@ class FileCachePendingFiles extends Lockable {
 
 class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<T> {
   private final DirectoryRegistry directoryRegistry = new DirectoryRegistryImpl();
-  private final Filter<TypedPath> filter = DirectoryRegistries.toTypedPathFilter(directoryRegistry);
+  private final Filter<TypedPath> filter;
   private final Converter<T> converter;
   private final CacheObservers<T> observers = new CacheObservers<>();
   private final Executor callbackExecutor;
@@ -125,12 +125,29 @@ class FileCacheDirectoryTree<T> implements ObservableCache<T>, FileTreeDataView<
       final SymlinkWatcher symlinkWatcher,
       final boolean rescanOnDirectoryUpdate,
       final Logger logger) {
+    this(
+        converter,
+        callbackExecutor,
+        symlinkWatcher,
+        rescanOnDirectoryUpdate,
+        Loggers.getLogger(),
+        null);
+  }
+
+  FileCacheDirectoryTree(
+      final Converter<T> converter,
+      final Executor callbackExecutor,
+      final SymlinkWatcher symlinkWatcher,
+      final boolean rescanOnDirectoryUpdate,
+      final Logger logger,
+      final Filter<TypedPath> filter) {
     this.converter = converter;
     this.callbackExecutor = callbackExecutor;
     this.symlinkWatcher = symlinkWatcher;
     this.followLinks = symlinkWatcher != null;
     this.rescanOnDirectoryUpdate = rescanOnDirectoryUpdate;
     this.logger = logger;
+    this.filter = DirectoryRegistries.toTypedPathFilter(directoryRegistry, filter);
     if (symlinkWatcher != null) {
       final boolean log = System.getProperty("swoval.symlink.debug", "false").equals("true");
       symlinkWatcher.addObserver(

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeRepositories.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeRepositories.java
@@ -3,6 +3,7 @@ package com.swoval.files;
 import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeViews.Observer;
 import com.swoval.files.PathWatchers.Event;
+import com.swoval.functional.Filter;
 import com.swoval.logging.Logger;
 import com.swoval.logging.Loggers;
 import java.io.IOException;
@@ -42,6 +43,27 @@ public class FileTreeRepositories {
    *     FileTreeRepository#register}) and will trigger an event when any of the included children
    *     are modified. When false, symbolic links are not followed and only events for the symbolic
    *     link itself are reported.
+   * @param <T> the value type of the cache entries
+   * @return a file tree repository.
+   * @throws InterruptedException if the path watcher can't be started.
+   * @throws IOException if an instance of {@link java.nio.file.WatchService} cannot be created.
+   */
+  public static <T> FileTreeRepository<T> get(
+      final Converter<T> converter, final Filter<TypedPath> filter, final boolean followLinks)
+      throws InterruptedException, IOException {
+    return get(converter, filter, followLinks, false, Loggers.getLogger());
+  }
+  /**
+   * Create a file tree repository.
+   *
+   * @param converter converts a path to the cached value type T
+   * @param followLinks toggles whether or not to follow symbolic links. When true, any symbolic
+   *     links that point to a regular file will trigger an event when the target file is modified.
+   *     For any symbolic links that point to a directory, the children of the target directory will
+   *     be included (up to the max depth parameter specified by {@link
+   *     FileTreeRepository#register}) and will trigger an event when any of the included children
+   *     are modified. When false, symbolic links are not followed and only events for the symbolic
+   *     link itself are reported.
    * @param rescanOnDirectoryUpdates toggles whether or not we rescan a directory's subtree when an
    *     update is detected for that directory. This can be very expensive since it will perform
    *     iops proportional to the number of files in the subtree. It generally should not be
@@ -58,6 +80,37 @@ public class FileTreeRepositories {
       final boolean rescanOnDirectoryUpdates,
       final Logger logger)
       throws InterruptedException, IOException {
+    return get(converter, null, followLinks, rescanOnDirectoryUpdates, logger);
+  }
+  /**
+   * Create a file tree repository.
+   *
+   * @param converter converts a path to the cached value type T
+   * @param filter only cache paths accepted by this filter
+   * @param followLinks toggles whether or not to follow symbolic links. When true, any symbolic
+   *     links that point to a regular file will trigger an event when the target file is modified.
+   *     For any symbolic links that point to a directory, the children of the target directory will
+   *     be included (up to the max depth parameter specified by {@link
+   *     FileTreeRepository#register}) and will trigger an event when any of the included children
+   *     are modified. When false, symbolic links are not followed and only events for the symbolic
+   *     link itself are reported.
+   * @param rescanOnDirectoryUpdates toggles whether or not we rescan a directory's subtree when an
+   *     update is detected for that directory. This can be very expensive since it will perform
+   *     iops proportional to the number of files in the subtree. It generally should not be
+   *     necessary since we are also watching the subtree for events.
+   * @param logger logs debug events
+   * @param <T> the value type of the cache entries
+   * @return a file tree repository.
+   * @throws InterruptedException if the path watcher can't be started.
+   * @throws IOException if an instance of {@link java.nio.file.WatchService} cannot be created.
+   */
+  public static <T> FileTreeRepository<T> get(
+      final Converter<T> converter,
+      final Filter<TypedPath> filter,
+      final boolean followLinks,
+      final boolean rescanOnDirectoryUpdates,
+      final Logger logger)
+      throws InterruptedException, IOException {
     final SymlinkWatcher symlinkWatcher =
         followLinks
             ? new SymlinkWatcher(
@@ -66,7 +119,7 @@ public class FileTreeRepositories {
     final Executor callbackExecutor = Executor.make("FileTreeRepository-callback-executor");
     final FileCacheDirectoryTree<T> tree =
         new FileCacheDirectoryTree<>(
-            converter, callbackExecutor, symlinkWatcher, rescanOnDirectoryUpdates, logger);
+            converter, callbackExecutor, symlinkWatcher, rescanOnDirectoryUpdates, logger, filter);
     final PathWatcher<PathWatchers.Event> pathWatcher =
         PathWatchers.get(false, tree.readOnlyDirectoryRegistry(), logger);
     pathWatcher.addObserver(


### PR DESCRIPTION
There is a bit of an oversight in the existing library that the
FileTreeRepository does not currently permit users to filter for
specific files. This can cause excessive memory utilization tracking
state for files that the user doesn't care about. There also is a lot of
extra work being done behind the scenes to apply the converter function
(which might, for example, hash the file contents) for unneeded files.
The underlying data structures backing the FileTreeRepository support
filtering so I'm not sure why I left that functionality out in the past.

This came up in the context of #155 and
https://github.com/scalameta/metals/pull/3758#pullrequestreview-922146225