### PR TITLE
Default Windows to use nioDirectoryLister

### DIFF
--- a/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
+++ b/files/js/src/main/scala/com/swoval/files/FileTreeViews.scala
@@ -7,6 +7,7 @@ import com.swoval.files.FileTreeDataViews.Converter
 import com.swoval.files.FileTreeDataViews.Entry
 import com.swoval.functional.Filter
 import com.swoval.functional.Filters
+import com.swoval.runtime.Platform;
 import java.io.IOException
 import java.nio.file.Path
 import java.util.ArrayList
@@ -21,8 +22,10 @@ object FileTreeViews {
   val nioLister: DirectoryLister = new NioDirectoryLister()
 
   val defaultLister: DirectoryLister =
+    //Note: Windows defaults to use nioLister due to performance reasons, see issue #161
+
     if (listers(1) != null) listers(1)
-    else if (listers(0) != null) listers(0)
+    else if (!Platform.IsWin && listers(0) != null) listers(0)
     else nioLister
 
   private val nioDirectoryLister: DirectoryLister = nioLister

--- a/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
+++ b/files/jvm/src/main/java/com/swoval/files/FileTreeViews.java
@@ -5,6 +5,7 @@ import com.swoval.files.FileTreeDataViews.Converter;
 import com.swoval.files.FileTreeDataViews.Entry;
 import com.swoval.functional.Filter;
 import com.swoval.functional.Filters;
+import com.swoval.runtime.Platform;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,7 +24,10 @@ public class FileTreeViews {
     DirectoryLister nioLister = new NioDirectoryLister();
     nioDirectoryLister = nioLister;
     DirectoryLister defaultLister =
-        listers[1] != null ? listers[1] : listers[0] != null ? listers[0] : nioLister;
+        // Note: Windows defaults to use nioLister due to performance reasons, see issue #161
+        listers[1] != null
+            ? listers[1]
+            : (!Platform.isWin() && listers[0] != null) ? listers[0] : nioLister;
     defaultDirectoryLister = defaultLister;
     defaultFileTreeView = new SimpleFileTreeView(defaultLister, false);
   }


### PR DESCRIPTION
This is implementation of #161, where Windows now defaults to use the nioDirectoryLister (instead of the native DirectoryLister).

After some profiling, it was determined that, on Windows, the nioDirectoryLister seems to be orders of magnitude faster than the nativeDirectoryLister. It is unclear exactly why, but we suspect it is the JNI calls that are slow.